### PR TITLE
Add ts options for high-frequency model output

### DIFF
--- a/templates/default.ini
+++ b/templates/default.ini
@@ -46,6 +46,8 @@ grid = string(default="")
 area_nm = string(default="area")
 vars = string(default="FSNTOA,FLUT,FSNT,FLNT,FSNS,FLNS,SHFLX,QFLX,TAUX,TAUY,PRECC,PRECL,PRECSC,PRECSL,TS,TREFHT,CLDTOT,CLDHGH,CLDMED,CLDLOW")
 years = string_list(default=list(""))
+dpf = integer(default=30)
+tpd = integer(default=1)
 
   [[__many__]]
   active = boolean(default=None)
@@ -59,6 +61,8 @@ years = string_list(default=list(""))
   area_nm = string(default=None)
   vars = string(default=None)
   years = string_list(default=None)
+  dpf = integer(default=30)
+  tpd = integer(default=1)
 
 [glb]
 active = boolean(default=True)

--- a/templates/default.ini
+++ b/templates/default.ini
@@ -61,8 +61,8 @@ tpd = integer(default=1)
   area_nm = string(default=None)
   vars = string(default=None)
   years = string_list(default=None)
-  dpf = integer(default=30)
-  tpd = integer(default=1)
+  dpf = integer(default=None)
+  tpd = integer(default=None)
 
 [glb]
 active = boolean(default=True)

--- a/templates/ts.bash
+++ b/templates/ts.bash
@@ -76,6 +76,8 @@ ncclimo \
 {%- endif %}
 {%- if frequency != 'monthly' %}
 --clm_md=hfs \
+--dpf={{ dpf }} \
+--tpd={{ tpd }} \
 {%- endif %}
 {{ case }}.{{ input_files }}.????-*.nc
 


### PR DESCRIPTION
The ncclimo command requires day-per-file (dpf) and time-per-day (tpd) information to correctly handle high-frequency model output.

Tested successfully on compy with the config file: /qfs/people/tang338/E3SM/utils/zppy/20210326_chemUCI.beta1_01.amip.ne30pg2_r05_oECv3.compy.cfg