### PR TITLE
skip overlapped data from multiple moc files in global_time_series/coupled_global.py

### DIFF
--- a/global_time_series/coupled_global.py
+++ b/global_time_series/coupled_global.py
@@ -24,7 +24,7 @@ def getmoc(dir_in):
     var0 = fin['mocAtlantic26'][:]
     for iyear in range(np.int(time0[0]),np.int(time0[-1])+1):
         if(i>0 and iyear <= time[-1]):
-          #print('the amoc value for year',iyear, 'has been included in the moc time series from another moc file',files[i-1], time[-1], 'Skipping...')
+          print('the amoc value for year',iyear, 'has been included in the moc time series from another moc file',files[i-1], time[-1], 'Skipping...')
         else:
           imon = np.where(time0==iyear)[0]
           if(len(imon)==12):

--- a/global_time_series/coupled_global.py
+++ b/global_time_series/coupled_global.py
@@ -23,12 +23,16 @@ def getmoc(dir_in):
     time0=fin['year'][:]
     var0 = fin['mocAtlantic26'][:]
     for iyear in range(np.int(time0[0]),np.int(time0[-1])+1):
-     imon = np.where(time0==iyear)[0]
-     if(len(imon)==12):
-      var=np.append(var,np.mean(var0[imon]))
-      time=np.append(time,iyear)
-     else:
-      print('error in input file :',files[i])
+        if(i>0 and iyear <= time[-1]):
+          #print('the amoc value for year',iyear, 'has been included in the moc time series from another moc file',files[i-1], time[-1], 'Skipping...')
+        else:
+          imon = np.where(time0==iyear)[0]
+          if(len(imon)==12):
+            var=np.append(var,np.mean(var0[imon]))
+            time=np.append(time,iyear)
+          else:
+            print('error in input file :',files[i])
+
  return time,var
 
 # -----------------------------------------------------------------------------
@@ -102,7 +106,7 @@ exps = [
    'vol':'{}/post/ocn/glb/ts/monthly/10yr/glb.xml'.format(case_dir),
    'name': experiment_name,
    'yoffset':0.0,
-   'yr':([21,100],),
+   'yr':([1,100],),
    'color':'Blue'},
 
 ]


### PR DESCRIPTION
function getmoc() in global_time_series/coupled_global.py has been updated to skip the overlapping among multiple mocTimeseries files  