### PR TITLE
Use latest E3SM Diags

### DIFF
--- a/templates/default.ini
+++ b/templates/default.ini
@@ -93,6 +93,7 @@ output_format_subplot = string_list(default=list(""))
 multiprocessing = boolean(default=True)
 num_workers = integer(default=24)
 vars = string(default="FSNTOA,FLUT,FSNT,FLNT,FSNS,FLNS,SHFLX,QFLX,TAUX,TAUY,PRECC,PRECL,PRECSC,PRECSL,TS,TREFHT,CLDTOT,CLDHGH,CLDMED,CLDLOW,U")
+environment_commands = string(default="")
 
   [[__many__]]
   active = boolean(default=None)
@@ -113,6 +114,7 @@ vars = string(default="FSNTOA,FLUT,FSNT,FLNT,FSNS,FLNS,SHFLX,QFLX,TAUX,TAUY,PREC
   multiprocessing = boolean(default=None)
   num_workers = integer(default=None)
   vars = string(default=None)
+  environment_commands = string(default=None)
 
 [e3sm_diags_vs_model]
 active = boolean(default=True)


### PR DESCRIPTION
Add changes that require the latest E3SM Diags updates. Those E3SM Diags updates will be available in the next `unified` environment but are not in the current `unified` environment. So, we also need to allow `zppy` to use an environment other than `unified` during development.