### PR TITLE
Print e3sm diags output

### DIFF
--- a/templates/e3sm_diags.bash
+++ b/templates/e3sm_diags.bash
@@ -187,9 +187,9 @@ EOF
 cat > e3sm_diags.cfg << EOF
 {% include cfg %}
 EOF
-command="python e3sm.py -d e3sm_diags.cfg"
+command="python -u e3sm.py -d e3sm_diags.cfg"
 {% else %}
-command="python e3sm.py"
+command="python -u e3sm.py"
 {% endif %}
 
 # Run diagnostics


### PR DESCRIPTION
Remove buffering to ensure errors are printed in the log file. Resolves #13.