### PR TITLE
Add GitHub Actions release workflow

### DIFF
--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -1,0 +1,46 @@
+name: CI/CD Release Workflow
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-to-anaconda:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Cache Conda
+        uses: actions/cache@v2
+        env:
+          CACHE_NUMBER: 0
+        with:
+          path: ~/conda_pkgs_dir
+          key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-publish
+
+      - name: Set up Conda Environment
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: "zppy_publish"
+          channel-priority: strict
+          python-version: 3.7
+          auto-update-conda: true
+          # IMPORTANT: This needs to be set for caching to work properly!
+          use-only-tar-bz2: true
+
+      - name: Additional Conda Config
+        run: |
+          conda install anaconda-client conda-build conda-verify
+          conda config --set anaconda_upload no
+
+      - name: Build Conda Package
+        run: conda build -c conda-forge --output-folder . .
+
+      - name: Publish to Anaconda
+        env:
+          ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
+        run: anaconda upload --label main noarch/*.tar.bz2 --force

--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ simulations by automating commonly performed tasks.
 
 See [documentation](https://e3sm-project.github.io/zppy) for more details.
 
-Run `python -m unittest discover -s tests -p "test_*.py"` to run all tests.
-Run `python -m unittest tests/test_*.py` to run only unit tests.
-Run `python -m unittest tests/integration/test_*.py` to run only integration tests (on server)
+- Run `python -m unittest discover -s tests -p "test_*.py"` to run all tests.
+- Run `python -m unittest tests/test_*.py` to run only unit tests.
+- Run `python -m unittest tests/integration/test_*.py` to run only integration tests (on server).


### PR DESCRIPTION
This PR adds a GitHub Actions release workflow which automates jobs after every GitHub release.

Currently, it supports publishing to Anaconda (#43). We can tackle automating docs (#44) after v1.0.0 release.

- Closes #43 