### PR TITLE
Add conda channel label assignment in release workflow

### DIFF
--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -40,7 +40,14 @@ jobs:
       - name: Build Conda Package
         run: conda build -c conda-forge --output-folder . .
 
-      - name: Publish to Anaconda
+      - name: Publish to Anaconda (e3sm channel)
         env:
           ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
-        run: anaconda upload --label main noarch/*.tar.bz2 --force
+          ANACONDA_CHANNEL_LABEL: "main"
+        run: |
+          if [[ noarch/*.tar.bz2 == *"rc"*.tar.bz2 ]];
+          then
+            export ANACONDA_CHANNEL_LABEL="e3sm_dev"
+          fi;
+
+          anaconda upload --label $ANACONDA_CHANNEL_LABEL noarch/*.tar.bz2 --force

--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -43,11 +43,14 @@ jobs:
       - name: Publish to Anaconda (e3sm channel)
         env:
           ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
-          ANACONDA_CHANNEL_LABEL: "main"
         run: |
-          if [[ noarch/*.tar.bz2 == *"rc"*.tar.bz2 ]];
-          then
-            export ANACONDA_CHANNEL_LABEL="e3sm_dev"
-          fi;
+          label="main"
 
-          anaconda upload --label $ANACONDA_CHANNEL_LABEL noarch/*.tar.bz2 --force
+          for file in noarch/*.tar.bz2; do
+            if [[ "$file" == noarch/*"rc"*.tar.bz2 ]]; then
+               label="e3sm_dev"
+            fi
+          done
+
+          echo Uploading to conda-forge with \'$label\' label
+          anaconda upload --label $label ../noarch/*.tar.bz2 --force


### PR DESCRIPTION
Production builds publish to `e3sm/main` and RC builds publish to `e3sm/e3sm_dev`.

- Closes #53 