### PR TITLE
Release v1.0.0rc2

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "zppy" %}
-{% set version = "1.0.0rc1" %}
+{% set version = "1.0.0rc2" %}
 
 package:
   name: {{ name|lower }}

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ data_files = package_files('zppy', prefixes=[], extensions=['bash', 'csh', 'ini'
 
 setup(
     name="zppy",
-    version="1.0.0rc1",
+    version="1.0.0rc2",
     author="Ryan Forsyth, Chris Golaz",
     author_email="forsyth2@llnl.gov, golaz1@llnl.gov",
     description="Post-processing software for E3SM",

--- a/zppy/__init__.py
+++ b/zppy/__init__.py
@@ -1,1 +1,1 @@
-__version__ = 'v1.0.0rc1'
+__version__ = 'v1.0.0rc2'


### PR DESCRIPTION
Release v1.0.0rc2.

This should be merged after #63, #64, #65, and #68 have been merged. Then, https://github.com/E3SM-Project/zppy/releases can be updated.