### PR TITLE
fix test name for diurnal cycle e3sm-diags run

### DIFF
--- a/zppy/templates/e3sm_diags.bash
+++ b/zppy/templates/e3sm_diags.bash
@@ -187,7 +187,6 @@ params.append(ts_param)
 dc_param = DiurnalCycleParameter()
 dc_param.reference_data_path = '{{ dc_obs_climo }}'
 dc_param.test_data_path = 'climo_{{ climo_diurnal_subsection }}'
-dc_param.test_name = short_name
 dc_param.short_test_name = short_name
 # Plotting diurnal cycle amplitude on different scales. Default is True
 dc_param.normalize_test_amp = False


### PR DESCRIPTION
This PR fixes an issue that diurnal cycle in e3sm-diags runs won't run. i.e. ""OSError: No file found for 20210603.v2rc3c.piControl.naRRM and JJA in climo_atm_monthly_diurnal_8xdaily_180x360_aave"" where `20210603.v2rc3c.piControl.naRRM` is a user specified `short_name`, but `test_name` should be used to search for required diurnal cycle climatology files.