### PR TITLE
Fixes for rc4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,8 @@ zppy.egg-info/
 *~
 \#*
 
-tests/image_check_failures
+tests/integration/image_check_failures
+test_output
 
 # Sphinx documentation
 docs/_build/

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     description="Post-processing software for E3SM",
     python_requires=">=3.6",
     intall_requires=["configobj", "jinja2"],
-    packages=find_packages(exclude=["*.test", "*.test.*", "test.*", "test"]),
+    packages=find_packages(include=["zppy", "zppy.*"]),
     package_data={"": data_files},
     entry_points={"console_scripts": ["zppy=zppy.__main__:main"]},
 )

--- a/tests/integration/test_complete_run.py
+++ b/tests/integration/test_complete_run.py
@@ -19,7 +19,7 @@ def compare_images(
     expected_png = Image.open(path_to_expected_png).convert("RGB")
     diff = ImageChops.difference(actual_png, expected_png)
 
-    diff_dir = "tests/image_check_failures"
+    diff_dir = "tests/integration/image_check_failures"
     if not os.path.isdir(diff_dir):
         os.mkdir(diff_dir)
 

--- a/tests/integration/test_environment_commands.py
+++ b/tests/integration/test_environment_commands.py
@@ -19,7 +19,7 @@ def compare_images(
     expected_png = Image.open(path_to_expected_png).convert("RGB")
     diff = ImageChops.difference(actual_png, expected_png)
 
-    diff_dir = "tests/image_check_failures"
+    diff_dir = "tests/integration/image_check_failures"
     if not os.path.isdir(diff_dir):
         os.mkdir(diff_dir)
 

--- a/zppy/amwg.py
+++ b/zppy/amwg.py
@@ -64,6 +64,7 @@ def amwg(config, scriptDir):
                     scriptFile, dependFiles=dependencies, export="NONE"
                 )
 
-                # Update status file
-                with open(statusFile, "w") as f:
-                    f.write("WAITING %d\n" % (jobid))
+                if jobid != -1:
+                    # Update status file
+                    with open(statusFile, "w") as f:
+                        f.write("WAITING %d\n" % (jobid))

--- a/zppy/climo.py
+++ b/zppy/climo.py
@@ -74,6 +74,7 @@ def climo(config, scriptDir):
                 # Submit job
                 jobid = submitScript(scriptFile)
 
-                # Update status file
-                with open(statusFile, "w") as f:
-                    f.write("WAITING %d\n" % (jobid))
+                if jobid != -1:
+                    # Update status file
+                    with open(statusFile, "w") as f:
+                        f.write("WAITING %d\n" % (jobid))

--- a/zppy/e3sm_diags.py
+++ b/zppy/e3sm_diags.py
@@ -88,6 +88,7 @@ def e3sm_diags(config, scriptDir):
                     scriptFile, dependFiles=dependencies, export="NONE"
                 )
 
-                # Update status file
-                with open(statusFile, "w") as f:
-                    f.write("WAITING %d\n" % (jobid))
+                if jobid != -1:
+                    # Update status file
+                    with open(statusFile, "w") as f:
+                        f.write("WAITING %d\n" % (jobid))

--- a/zppy/e3sm_diags_vs_model.py
+++ b/zppy/e3sm_diags_vs_model.py
@@ -74,6 +74,7 @@ def e3sm_diags_vs_model(config, scriptDir):
                     scriptFile, dependFiles=dependencies, export="NONE"
                 )
 
-                # Update status file
-                with open(statusFile, "w") as f:
-                    f.write("WAITING %d\n" % (jobid))
+                if jobid != -1:
+                    # Update status file
+                    with open(statusFile, "w") as f:
+                        f.write("WAITING %d\n" % (jobid))

--- a/zppy/global_time_series.py
+++ b/zppy/global_time_series.py
@@ -44,7 +44,8 @@ def global_time_series(config, scriptDir):
             c["global_time_series_dir"] = os.path.join(
                 scriptDir, "{}_dir".format(prefix)
             )
-            os.mkdir(c["global_time_series_dir"])
+            if not os.path.exists(c["global_time_series_dir"]):
+                os.mkdir(c["global_time_series_dir"])
             scripts = ["coupled_global.py", "readTS.py", "ocean_month.py"]
             for script in scripts:
                 script_template = templateEnv.get_template(script)
@@ -97,6 +98,7 @@ def global_time_series(config, scriptDir):
                     scriptFile, dependFiles=dependencies, export="NONE"
                 )
 
-                # Update status file
-                with open(statusFile, "w") as f:
-                    f.write("WAITING %d\n" % (jobid))
+                if jobid != -1:
+                    # Update status file
+                    with open(statusFile, "w") as f:
+                        f.write("WAITING %d\n" % (jobid))

--- a/zppy/mpas_analysis.py
+++ b/zppy/mpas_analysis.py
@@ -92,9 +92,12 @@ def mpas_analysis(config, scriptDir):
                 # Submit job
                 jobid = submitScript(scriptFile, dependFiles=dependencies)
 
-                # Update status file
-                with open(statusFile, "w") as f:
-                    f.write("WAITING %d\n" % (jobid))
+                if jobid != -1:
+                    # Update status file
+                    with open(statusFile, "w") as f:
+                        f.write("WAITING %d\n" % (jobid))
 
+                # Note that this line should still be executed even if jobid == -1
+                # The later MPAS-Analysis tasks still depend on this task (and thus will also fail).
                 # Add to the dependency list
                 dependencies.append(statusFile)

--- a/zppy/templates/climo.bash
+++ b/zppy/templates/climo.bash
@@ -108,6 +108,7 @@ ncclimo \
 
 {% else %}
 # --- Unsupported climatology mode ---
+cd {{ scriptDir }}
 echo 'Frequency '{{ frequency }}' is not a valid option'
 echo 'ERROR (1)' > {{ prefix }}.status
 exit 1
@@ -115,7 +116,7 @@ exit 1
 {%- endif %}
 
 if [ $? != 0 ]; then
-  cd ..
+  cd {{ scriptDir }}
   echo 'ERROR (2)' > {{ prefix }}.status
   exit 2
 fi
@@ -138,7 +139,7 @@ fi
 {%- endif %}
 
 if [ $? != 0 ]; then
-  cd ..
+  cd {{ scriptDir }}
   echo 'ERROR (3)' > {{ prefix }}.status
   exit 3
 fi

--- a/zppy/templates/default.ini
+++ b/zppy/templates/default.ini
@@ -161,6 +161,7 @@ generate = string_list(default=list('all', 'no_landIceCavities', 'no_BGC', 'no_i
 
 [global_time_series]
 active = boolean(default=True)
+qos = string(default="regular")
 nodes = integer(default=1)
 walltime = string(default="02:00:00")
 color = string(default="Blue")

--- a/zppy/templates/e3sm_diags.bash
+++ b/zppy/templates/e3sm_diags.bash
@@ -80,8 +80,8 @@ do
   export CDMS_NO_MPI=true
   cdscan -x ${xml_name} -f ${v}_files.txt
   if [ $? != 0 ]; then
-      cd ../..
-      echo 'ERROR (4)' > {{ prefix }}.status
+      cd {{ scriptDir }}
+      echo 'ERROR (1)' > {{ prefix }}.status
       exit 1
   fi
 done
@@ -213,9 +213,9 @@ command="python -u e3sm.py"
 # Run diagnostics
 time ${command}
 if [ $? != 0 ]; then
-  cd ..
-  echo 'ERROR (1)' > {{ prefix }}.status
-  exit 1
+  cd {{ scriptDir }}
+  echo 'ERROR (2)' > {{ prefix }}.status
+  exit 2
 fi
 
 # Copy output to web server
@@ -227,9 +227,9 @@ echo
 f=${www}/${case}/e3sm_diags/{{ grid }}
 mkdir -p ${f}
 if [ $? != 0 ]; then
-  cd ..
-  echo 'ERROR (2)' > {{ prefix }}.status
-  exit 1
+  cd {{ scriptDir }}
+  echo 'ERROR (3)' > {{ prefix }}.status
+  exit 3
 fi
 
 {% if machine == 'cori' %}
@@ -249,9 +249,9 @@ done
 # Copy files
 rsync -a --delete ${results_dir} ${www}/${case}/e3sm_diags/{{ grid }}/
 if [ $? != 0 ]; then
-  cd ..
-  echo 'ERROR (3)' > {{ prefix }}.status
-  exit 1
+  cd {{ scriptDir }}
+  echo 'ERROR (4)' > {{ prefix }}.status
+  exit 4
 fi
 
 {% if machine == 'cori' %}

--- a/zppy/templates/e3sm_diags_vs_model.bash
+++ b/zppy/templates/e3sm_diags_vs_model.bash
@@ -109,7 +109,7 @@ EOF
 # Run diagnostics
 time python e3sm.py
 if [ $? != 0 ]; then
-  cd ..
+  cd {{ scriptDir }}
   echo 'ERROR (1)' > {{ prefix }}.status
   exit 1
 fi
@@ -123,7 +123,7 @@ echo
 f=${www}/${case}/e3sm_diags/{{ grid }}
 mkdir -p ${f}
 if [ $? != 0 ]; then
-  cd ..
+  cd {{ scriptDir }}
   echo 'ERROR (2)' > {{ prefix }}.status
   exit 1
 fi
@@ -145,7 +145,7 @@ done
 # Copy files
 rsync -a --delete ${results_dir} ${www}/${case}/e3sm_diags/{{ grid }}/
 if [ $? != 0 ]; then
-  cd ..
+  cd {{ scriptDir }}
   echo 'ERROR (3)' > {{ prefix }}.status
   exit 1
 fi

--- a/zppy/templates/global_time_series.bash
+++ b/zppy/templates/global_time_series.bash
@@ -41,6 +41,11 @@ echo 'Create xml files for atm'
 export CDMS_NO_MPI=true
 cd ${case_dir}/post/atm/glb/ts/monthly/10yr
 cdscan -x glb.xml *.nc
+if [ $? != 0 ]; then
+  cd {{ scriptDir }}
+  echo 'ERROR (1)' > {{ prefix }}.status
+  exit 1
+fi
 
 echo 'Create ocean time series'
 cd ${global_ts_dir}
@@ -51,6 +56,12 @@ echo 'Create xml for for ocn'
 export CDMS_NO_MPI=true
 cd ${case_dir}/post/ocn/glb/ts/monthly/10yr
 cdscan -x glb.xml *.nc
+if [ $? != 0 ]; then
+  cd {{ scriptDir }}
+  echo 'ERROR (2)' > {{ prefix }}.status
+  exit 2
+fi
+
 
 echo 'Copy moc file'
 cd ${case_dir}/post/analysis/mpas_analysis/cache/timeseries/moc
@@ -77,9 +88,9 @@ echo
 f=${www}/${case}/global_time_series
 mkdir -p ${f}
 if [ $? != 0 ]; then
-  cd ..
-  echo 'ERROR (1)' > {{ prefix }}.status
-  exit 1
+  cd {{ scriptDir }}
+  echo 'ERROR (3)' > {{ prefix }}.status
+  exit 3
 fi
 
 {% if machine == 'cori' %}
@@ -99,9 +110,9 @@ done
 # Copy files
 rsync -a --delete ${results_dir_absolute_path} ${www}/${case}/global_time_series
 if [ $? != 0 ]; then
-  cd ..
-  echo 'ERROR (2)' > {{ prefix }}.status
-  exit 1
+  cd {{ scriptDir }}
+  echo 'ERROR (4)' > {{ prefix }}.status
+  exit 4
 fi
 
 {% if machine == 'cori' %}

--- a/zppy/templates/mpas_analysis.bash
+++ b/zppy/templates/mpas_analysis.bash
@@ -310,7 +310,7 @@ size=`wc -c ${identifier}/logs/taskProgress.log | awk '{print $1}'`
 error=`grep ERROR ${identifier}/logs/taskProgress.log | wc -l`
 if [ "${size}" = "" ] || [ "${size}" = "0" ] || [ "${error}" != "0" ];then
   echo 'ERROR (2)' > {{ scriptDir }}/{{ prefix }}.status
-  exit 1
+  exit 2
 fi
 
 {% if cache == true %}
@@ -334,7 +334,7 @@ f=${www}/${case}/mpas_analysis/${identifier}/
 mkdir -p ${f}
 if [ $? != 0 ]; then
   echo 'ERROR (3)' > {{ scriptDir }}/{{ prefix }}.status
-  exit 1
+  exit 3
 fi
 
 {% if machine == 'cori' %}
@@ -355,7 +355,7 @@ done
 rsync -a --delete ${identifier}/html/ ${www}/${case}/mpas_analysis/${identifier}/
 if [ $? != 0 ]; then
   echo 'ERROR (4)' > {{ scriptDir }}/{{ prefix }}.status
-  exit 1
+  exit 4
 fi
 
 {% if machine == 'cori' %}

--- a/zppy/templates/ts.bash
+++ b/zppy/templates/ts.bash
@@ -82,7 +82,7 @@ ncclimo \
 {{ case }}.{{ input_files }}.????-*.nc
 
 if [ $? != 0 ]; then
-  cd ..
+  cd {{ scriptDir }}
   echo 'ERROR (1)' > {{ prefix }}.status
   exit 1
 fi
@@ -94,7 +94,7 @@ fi
   mv output/*.nc ${dest}
 }
 if [ $? != 0 ]; then
-  cd ..
+  cd {{ scriptDir }}
   echo 'ERROR (2)' > {{ prefix }}.status
   exit 2
 fi

--- a/zppy/ts.py
+++ b/zppy/ts.py
@@ -82,6 +82,7 @@ def ts(config, scriptDir):
                 # Submit job
                 jobid = submitScript(scriptFile)
 
-                # Update status file
-                with open(statusFile, "w") as f:
-                    f.write("WAITING %d\n" % (jobid))
+                if jobid != -1:
+                    # Update status file
+                    with open(statusFile, "w") as f:
+                        f.write("WAITING %d\n" % (jobid))


### PR DESCRIPTION
Fixes for rc4

- Add default `qos` for global time series.
- Update error codes for each bash template to 1) be in the same order as they appear in the file and 2) exit with the same error code that is printed.
- Only create global time series directory if it doesn't already exist. (One bug mentioned in #88).
- Update `.gitignore` and paths for testing.
- Don't create status file if a dependency's status file is missing. (Another bug mentioned in #88).
- Update packages in `setup.py`. Resolves #94.