### PR TITLE
Add tbump to simplify version bumping

### DIFF
--- a/conda/dev.yml
+++ b/conda/dev.yml
@@ -4,12 +4,14 @@ channels:
   - defaults
 dependencies:
   # Base
+  # =================
   - configobj=5.0.6
   - jinja2=2.11.3
   - pillow=8.1.2
   - pip=21.0.1
   - python=3.7.10
   # Developer Tools
+  # =================
   # If versions are updated, also update 'rev' in `.pre-commit.config.yaml`
   - black=21.5b2        # version from https://anaconda.org/conda-forge/black
   - flake8=3.9.2        # version from https://anaconda.org/conda-forge/flake8
@@ -19,8 +21,13 @@ dependencies:
   - pre-commit=2.13.0   # version from https://anaconda.org/conda-forge/pre-commit
   # Documentation
   # If versions are updated, also update in `.github/workflows/workflow.yml`
+  # =================
   - sphinx=3.5.1
   - sphinx_rtd_theme=0.5.1
+  # Need to pin docutils because 0.17 has a bug with unordered lists
+  # https://github.com/readthedocs/sphinx_rtd_theme/issues/1115
+  - docutils=0.16
   - pip:
       - sphinx-multiversion==0.2.4
+      - tbump==6.3.2
 prefix: /opt/miniconda3/envs/zppy_dev

--- a/docs/source/dev_guide/release.rst
+++ b/docs/source/dev_guide/release.rst
@@ -3,124 +3,84 @@ How to Prepare a Release
 
 In this guide, we'll cover:
 
-* Preparing The Code For Release
-* Creating A Release On GitHub
+* Bumping the Version
+* Releasing On GitHub
 * Releasing The Software On Anaconda
 * Creating a New Version of the Documentation
 
+Bumping the Version
+-------------------
 
-Preparing The Code For Release
-------------------------------
-
-These steps entail modifying files before a release is made.
-
-1. Pull the lastest code from whatever branch you want to release from.
-It's usually ``main``.
+1. Checkout the latest ``main``.
+2. Checkout a branch with the name of the version.
 
     ::
 
-        git fetch <upstream-origin> main
-        git checkout -b <branch-name> <upstream-origin>/main
+        # Prepend "v" to <version>
+        # For release candidates, append "rc" to <version>
+        git checkout -b v<version>
+        git push --set-upstream origin v<version>
 
-
-2. Edit the ``version`` argument in ``setup.py`` to the new version.
-Don't prefix this with a "v".
-
-    .. code-block:: python
-
-        setup(
-            name="zppy",
-            version="1.0.0",
-            author="Ryan Forsyth, Chris Golaz",
-            author_email="forsyth2@llnl.gov, golaz1@llnl.gov",
-            description="Post-processing software for E3SM",
-            python_requires='>=3.6',
-            intall_requires=['configobj', 'jinja2'],
-            packages=find_packages(exclude=["*.test", "*.test.*", "test.*", "test"]),
-            package_data={'': data_files},
-            entry_points={"console_scripts": ["zppy=zppy.__main__:main"]},
-        )
-
-3. Edit ``__version__`` in ``zppy/__init__.py``.
-We use ``__version__`` when generating the webpages.
+3. Bump version using tbump.
 
     ::
 
-        __version__ = 'v1.0.0'
+        # Exclude "v" and <version> should match step 2
+        # --no-tag is required since tagging is handled in "Releasing on GitHub"
+        $ tbump <version> --no-tag
 
-4. Change the ``version`` and ``git_rev`` tag in ``conda/meta.yaml`` by setting ``version``.
-``version`` is what the version of the software will be on Anaconda and
-``git_rev`` is the tag that we'll setup on GitHub in the next section.
-
-    .. note::
-        When running ``conda build``, ``conda`` will download the code tagged by ``git_rev``.
-        Even though ``meta.yaml`` is in your local clone of the repo, running ``conda build``
-        from here **does not** build the package based on your local code.
-
-    ::
-
-        {% set name = "zppy" %}
-        {% set version = "1.0.0" %}
-
-5. Commit and push your changes.
-
-    ::
-
-        git commit -am 'Changes before release.'
-        git push <fork-origin> <branch-name>
-
-6. Create a pull request to the main repo and merge it.
+        :: Bumping from 1.0.0 to 1.1.0
+        => Would patch these files
+        - setup.py:26 version="1.0.0",
+        + setup.py:26 version="1.1.0",
+        - zppy/__init__.py:1 __version__ = "v1.0.0"
+        + zppy/__init__.py:1 __version__ = "v1.1.0"
+        - conda/meta.yaml:2 {% set version = "1.0.0" %}
+        + conda/meta.yaml:2 {% set version = "1.1.0" %}
+        - tbump.toml:5 current = "1.0.0"
+        + tbump.toml:5 current = "1.1.0"
+        => Would run these git commands
+        $ git add --update
+        $ git commit --message Bump to 1.1.0
+        $ git push origin v1.1.0
+        :: Looking good? (y/N)
+        >
+4. Create a pull request to the main repo and merge it.
 
 .. _github-release:
 
-Creating A Release On GitHub
-----------------------------
+Releasing on GitHub
+-------------------
 
-1. Go to the Releases on the GitHub repo of the project
-`here <https://github.com/E3SM-Project/zppy/releases>`_.
-and draft a new release.
+1. Draft a new release `here <https://github.com/E3SM-Project/zppy/releases>`_.
+2. Set `Tag version` to ``v<version>``, **including the "v"**. `@Target` should be ``main``.
+3. Set `Release title` to ``v<version>``, **including the "v"**.
+4. Use `Describe this release` to summarize the changelog.
 
-2. ``Tag version`` and ``Release title`` should both be the version, including the "v".
-(They should match ``git_rev`` in step 4 of the previous section).
-``Target`` should be ``main``. Use ``Describe this release`` to write what features
-the release adds. You can scroll through
-`zppy commits <https://github.com/E3SM-Project/zppy/commits/main>`_ to see
-what features have been added recently.
+   * You can scroll through `zppy commits <https://github.com/E3SM-Project/zppy/commits/main>`_ for a list of changes.
 
-Note that you can also change the branch which you want to release from,
-this is specified after the tag (@ Target: ``main``).
+5. If this version is a release candidate (``<version>`` appended with ``rc``), checkmark `This is a pre-release`.
+6. Click `Publish release`.
+7. CI/CD release workflow is automatically triggered.
 
-The title of a release is often the same as the tag, but you can set it to whatever you want.
+Releasing Anaconda
+------------------
 
-Remember to write a description.
-
-3. Click "Publish release".
-
-Releasing The Software On Anaconda
-----------------------------------
-
-1. Be sure to have already completed :ref:`Creating A Release On GitHub <github-release>`.
-This triggers the CI/CD workflow that handles Anaconda releases.
-
+1. Be sure to have already completed :ref:`Releasing On GitHub <github-release>`. This triggers the CI/CD workflow that handles Anaconda releases.
 2. Wait until the CI/CD build is successful. You can view all workflows at `All Workflows <https://github.com/E3SM-Project/zppy/actions>`_.
-
 3. Check the https://anaconda.org/e3sm/zppy page to view the newly updated package.
 
-4. Notify the maintainers of the unified E3SM environment about the new release on the
-`E3SM Confluence site <https://acme-climate.atlassian.net/wiki/spaces/WORKFLOW/pages/129732419/E3SM+Unified+Anaconda+Environment>`_.
-Be sure to only update the ``zppy`` version number in the correct version(s) of
-the E3SM Unified environment. This is almost certainly one of the versions listed under
-“Next versions”. If you are uncertain of which to update, leave a comment on the page
-asking.
+   * Release candidates are assigned the ``e3sm_dev`` label
+   * Production releases are assigned the ``main`` label
+
+4. Notify the maintainers of the unified E3SM environment about the new release on the `E3SM Confluence site <https://acme-climate.atlassian.net/wiki/spaces/WORKFLOW/pages/129732419/E3SM+Unified+Anaconda+Environment>`_.
+
+   * Be sure to only update the ``zppy`` version number in the correct version(s) of the E3SM Unified environment.
+   * This is almost certainly one of the versions listed under “Next versions”. If you are uncertain of which to update, leave a comment on the page asking.
 
 Creating a New Version of the Documentation
 -------------------------------------------
 
-1. Be sure to have already completed :ref:`Creating A Release On GitHub <github-release>`.
-This triggers the CI/CD workflow that handles publishing documentation versions.
-
-2. Wait until the CI/CD build is successful. You can view all workflows at
-`All Workflows <https://github.com/E3SM-Project/zppy/actions>`_.
-
-3. Changes will be available on the
-`zppy documentation page <https://e3sm-project.github.io/zppy/>`_.
+1. Be sure to have already completed :ref:`Releasing On GitHub <github-release>`. This triggers the CI/CD workflow that handles publishing documentation versions.
+2. Wait until the CI/CD build is successful. You can view all workflows at `All Workflows <https://github.com/E3SM-Project/zppy/actions>`_.
+3. Changes will be available on the `zppy documentation page <https://e3sm-project.github.io/zppy/>`_.

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,0 +1,46 @@
+# Uncomment this if your project is hosted on GitHub:
+github_url = "https://github.com/E3SM-Project/zppy.git"
+
+[version]
+current = "1.0.0"
+
+# Example of a semver regexp with support for PEP 440
+# release candidates.Make sure this matches current_version
+# before using tbump.
+regex = '''
+  (?P<major>\d+)
+  \.
+  (?P<minor>\d+)
+  \.
+  (?P<patch>\d+)((rc\d+)?)
+  '''
+
+[git]
+message_template = "Bump to {new_version}"
+tag_template = "v{new_version}"
+
+# For each file to patch, add a [[file]] config
+# section containing the path of the file, relative to the
+# tbump.toml location.
+[[file]]
+src = "setup.py"
+
+[[file]]
+src = "zppy/__init__.py"
+
+[[file]]
+src = "conda/meta.yaml"
+
+# You can specify a list of commands to
+# run after the files have been patched
+# and before the git commit is made
+
+#  [[before_commit]]
+#  name = "check changelog"
+#  cmd = "grep -q {new_version} Changelog.rst"
+
+# Or run some commands after the git tag and the branch
+# have been pushed:
+#  [[after_push]]
+#  name = "publish"
+#  cmd = "./publish.sh"


### PR DESCRIPTION
This PR adds `tbump` to simplify version bumping.

- Closes #54 

Additional Changes:
- Pin `docutils=0.16` in dev environment to avoid missing unordered bullets bug
  - The `publish-docs` step in both CI/CD workflows already pin `docutils=0.16`
- Update `releasing.rst` with latest steps to bump and release

Usage
------
Just run `tbump <version> --no-tag` to update the version in:
* `setup.py`
* `zppy/__init__.py`
* `conda/meta.yaml`
