### PR TITLE
Disable MPI in cdms2 before calling cdscan

### DIFF
--- a/zppy/templates/e3sm_diags.bash
+++ b/zppy/templates/e3sm_diags.bash
@@ -77,6 +77,7 @@ do
   done
   # xml file will cover the whole period from year1 to year2
   xml_name=${v}_${Y1}01_${Y2}12.xml
+  export CDMS_NO_MPI=true
   cdscan -x ${xml_name} -f ${v}_files.txt
   if [ $? != 0 ]; then
       cd ../..

--- a/zppy/templates/global_time_series.bash
+++ b/zppy/templates/global_time_series.bash
@@ -38,6 +38,7 @@ global_ts_dir={{ global_time_series_dir }}
 ################################################################################
 
 echo 'Create xml files for atm'
+export CDMS_NO_MPI=true
 cd ${case_dir}/post/atm/glb/ts/monthly/10yr
 cdscan -x glb.xml *.nc
 
@@ -47,6 +48,7 @@ mkdir -p ${case_dir}/post/ocn/glb/ts/monthly/10yr
 python ocean_month.py {{ input }} ${case_dir} ${start_yr} ${end_yr}
 
 echo 'Create xml for for ocn'
+export CDMS_NO_MPI=true
 cd ${case_dir}/post/ocn/glb/ts/monthly/10yr
 cdscan -x glb.xml *.nc
 


### PR DESCRIPTION
This merge sets the environment variable `CDMS_NO_MPI=true` before calling `cdscan` in 3 locations.  This will be harmless when `cdms2` is installed without `mpi4py` and will prevent errors in cases where `mpi4py` has been installed with system MPI, which does not work correctly with `cdms2`.