### PR TITLE
Shorten arguments for ncclimo

### DIFF
--- a/zppy/templates/climo.bash
+++ b/zppy/templates/climo.bash
@@ -83,8 +83,9 @@ then
 fi
 {%- endraw %}
 
+ls {{ case }}.{{ input_files }}.????-*.nc > input.txt
 # Now, call ncclimo
-ncclimo \
+cat input.txt | ncclimo \
 --case={{ case }}.{{ input_files }} \
 {%- if exclude %}
 -n '-x' \
@@ -103,8 +104,7 @@ ncclimo \
 --output=trash \
 --regrid=output \
 {%- endif %}
---climatology_mode=hfc \
-{{ case }}.{{ input_files }}.????-*.nc
+--climatology_mode=hfc
 
 {% else %}
 # --- Unsupported climatology mode ---

--- a/zppy/templates/ts.bash
+++ b/zppy/templates/ts.bash
@@ -56,8 +56,9 @@ fi
 {%- endraw %}
 {%- endif %}
 
+ls {{ case }}.{{ input_files }}.????-*.nc > input.txt
 # Generate time series files
-ncclimo \
+cat input.txt | ncclimo \
 -c {{ case }} \
 -v {{ vars }} \
 --yr_srt={{ yr_start }} \
@@ -79,7 +80,6 @@ ncclimo \
 --dpf={{ dpf }} \
 --tpd={{ tpd }} \
 {%- endif %}
-{{ case }}.{{ input_files }}.????-*.nc
 
 if [ $? != 0 ]; then
   cd {{ scriptDir }}


### PR DESCRIPTION
Shorten arguments for `ncclimo` calls related to diurnal cycle. Resolves #96.