### PR TITLE
Add machine name to the e3sm_unified path

### DIFF
--- a/zppy/__main__.py
+++ b/zppy/__main__.py
@@ -65,7 +65,7 @@ def main():
             )
         elif tmp.startswith("cori"):
             machine = "cori"
-            environment_commands = "source /global/cfs/cdirs/e3sm/software/anaconda_envs/load_{}_e3sm_unified_cori.sh".format(
+            environment_commands = "source /global/cfs/cdirs/e3sm/software/anaconda_envs/load_{}_e3sm_unified_cori-haswell.sh".format(
                 config["default"]["e3sm_unified"]
             )
         elif tmp.startswith("blues"):

--- a/zppy/__main__.py
+++ b/zppy/__main__.py
@@ -59,26 +59,26 @@ def main():
         if tmp.startswith("compy"):
             machine = "compy"
             environment_commands = (
-                "source /share/apps/E3SM/conda_envs/load_{}_e3sm_unified.sh".format(
+                "source /share/apps/E3SM/conda_envs/load_{}_e3sm_unified_compy.sh".format(
                     config["default"]["e3sm_unified"]
                 )
             )
         elif tmp.startswith("cori"):
             machine = "cori"
-            environment_commands = "source /global/cfs/cdirs/e3sm/software/anaconda_envs/load_{}_e3sm_unified.sh".format(
+            environment_commands = "source /global/cfs/cdirs/e3sm/software/anaconda_envs/load_{}_e3sm_unified_cori.sh".format(
                 config["default"]["e3sm_unified"]
             )
         elif tmp.startswith("blues"):
             machine = "anvil"
             environment_commands = (
-                "source /lcrc/soft/climate/e3sm-unified/load_{}_e3sm_unified.sh".format(
+                "source /lcrc/soft/climate/e3sm-unified/load_{}_e3sm_unified_anvil.sh".format(
                     config["default"]["e3sm_unified"]
                 )
             )
         elif tmp.startswith("chr"):
             machine = "chrysalis"
             environment_commands = (
-                "source /lcrc/soft/climate/e3sm-unified/load_{}_e3sm_unified.sh".format(
+                "source /lcrc/soft/climate/e3sm-unified/load_{}_e3sm_unified_chrysalis.sh".format(
                     config["default"]["e3sm_unified"]
                 )
             )


### PR DESCRIPTION
The latest e3sm_unified v1.5.0 version adds machine name to its path. Updated zppy with the new paths. Otherwise, the `source e3sm_unified*.sh` command will fail.

Tested successfully on chrysalis.