### PR TITLE
Update E3SM Diags testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ zppy.egg-info/
 \#*
 
 tests/integration/image_check_failures
-test_output
+test_bash_generation_output
 
 # Sphinx documentation
 docs/_build/

--- a/docs/source/dev_guide/testing.rst
+++ b/docs/source/dev_guide/testing.rst
@@ -1,10 +1,11 @@
+************
 Testing zppy
-============
+************
 
 Unit tests
-----------
+==========
 
-Run all unit tests by doing the following
+Run all unit tests by doing the following:
 
     .. code::
 
@@ -12,17 +13,90 @@ Run all unit tests by doing the following
         python -m unittest tests/test_*.py # Run all unit tests
 
 Integration tests
------------------
+=================
 
-Integration tests must be run on an LCRC machine.
+Integration tests must be run on an LCRC machine. Run all integration tests by doing the following:
 
     .. code::
 
         pip install . # Install your changes (`python -m pip install .` also works)
         python -m unittest tests/integration/test_*.py # Run all integration tests
 
+Commands to run before running integration tests
+------------------------------------------------
+
+Before running ``tests/integration/test_complete_run.py`` run the following:
+
+    .. code::
+
+       # You'll need to set some paths to your own directories:
+       # 1) Edit the paths below
+       # 2) Edit `output` and `www` parameters in `tests/integration/test_complete_run.cfg`
+       # 3) Edit `actual_images_dir` in `tests/integration/test_complete_run.py`
+       rm -rf /lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_test_complete_run_www/20210122.v2_test01.piControl.ne30pg2_EC30to60E2r2-1900_ICG.chrysalis
+       rm -rf /lcrc/group/e3sm/ac.forsyth2/zppy_test_complete_run_output/20210122.v2_test01.piControl.ne30pg2_EC30to60E2r2-1900_ICG.chrysalis/post
+       zppy -c tests/integration/test_complete_run.cfg
+
+Before running ``tests/integration/test_environment_commands.py`` run the following:
+
+    .. code::
+
+       # You'll need to set some paths to your own directories:
+       # 1) Edit the paths below
+       # 2) Edit `output`, `www`, and `environment_commands` parameters in `tests/integration/test_environment_commands.cfg`
+       # 3) Edit `actual_images_dir` in `tests/integration/test_environment_commands.py`
+       rm -rf /lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_test_environment_commands_www/20210122.v2_test01.piControl.ne30pg2_EC30to60E2r2-1900_ICG.chrysalis
+       rm -rf /lcrc/group/e3sm/ac.forsyth2/zppy_test_environment_commands_output/20210122.v2_test01.piControl.ne30pg2_EC30to60E2r2-1900_ICG.chrysalis/post
+       zppy -c tests/integration/test_environment_commands.cfg
+
+Commands to run to replace outdated expected files
+--------------------------------------------------
+       
+To replace the expected bash files for ``test_bash_generation.py`` run the following:
+
+    .. code::
+
+       rm -rf /lcrc/group/e3sm/public_html/zppy_test_resources/expected_bash_files
+       cd <top level of zppy repo>
+       # Your output will now become the new expectation.
+       # You can just move (i.e., not copy) the output since re-running this test will re-generate the output.
+       mv test_bash_generation_output/post/scripts /lcrc/group/e3sm/public_html/zppy_test_resources/expected_bash_files
+       # Rerun test
+       python -m unittest tests/integration/test_bash_generation.py       
+
+       
+To replace the expected images for ``test_complete_run.py`` run the following:
+
+    .. code::
+
+       rm -rf /lcrc/group/e3sm/public_html/zppy_test_resources/expected_complete_run
+       # Your output will now become the new expectation.
+       # Copy output so you don't have to rerun zppy to generate the output.
+       cp -r /lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_test_complete_run_www/20210122.v2_test01.piControl.ne30pg2_EC30to60E2r2-1900_ICG.chrysalis /lcrc/group/e3sm/public_html/zppy_test_resources/expected_complete_run
+       cd /lcrc/group/e3sm/public_html/zppy_test_resources/expected_complete_run
+       # This file will list all the expected images.
+       find . -type f -name '*.png' > ../image_list_expected_complete_run.txt
+       cd <top level of zppy repo>
+       # Rerun test
+       python -m unittest tests/integration/test_complete_run.py
+
+To replace the expected images for ``test_environment_commands.py`` run the following:
+
+    .. code::
+
+       rm -rf /lcrc/group/e3sm/public_html/zppy_test_resources/expected_environment_commands
+       # Your output will now become the new expectation.
+       # Copy output so you don't have to rerun zppy to generate the output.
+       cp -r /lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_test_environment_commands_www/20210122.v2_test01.piControl.ne30pg2_EC30to60E2r2-1900_ICG.chrysalis /lcrc/group/e3sm/public_html/zppy_test_resources/expected_environment_commands
+       cd /lcrc/group/e3sm/public_html/zppy_test_resources/expected_environment_commands
+       # This file will list all the expected images.
+       find . -type f -name '*.png' > ../image_list_expected_environment_commands.txt
+       cd <top level of zppy repo>
+       # Rerun test
+       python -m unittest tests/integration/test_environment_commands.py
+       
 Automated tests
----------------
+===============
 
 We have a :ref:`GitHub Actions <ci-cd>` Continuous Integration / Continuous Delivery (CI/CD) workflow.
 

--- a/tests/integration/test_bash_generation.cfg
+++ b/tests/integration/test_bash_generation.cfg
@@ -1,7 +1,7 @@
 [default]
 input = .
 input_subdir = archive/atm/hist
-output = test_output
+output = test_bash_generation_output
 case = case_name
 www = www/path
 e3sm_unified = latest
@@ -9,6 +9,7 @@ partition = compute
 ref_start_yr = 1979
 ref_final_yr = 2016
 dry_run = True
+environment_commands = "source /lcrc/soft/climate/e3sm-unified/load_latest_e3sm_unified_chrysalis.sh"
 
 [climo]
 active = True
@@ -65,8 +66,7 @@ active = False
 active = True
 years = "1:100:20", "1:100:50",
 ts_num_years = 10
-sets = "lat_lon","zonal_mean_xy","zonal_mean_2d","polar","cosp_histogram","meridional_mean_2d","enso_diags","area_mean_time_series","diurnal_cycle",
-#"qbo" with 50 years requires the latest E3SM Diags
+# Use default `sets`
 
   [[ atm_monthly_180x360_aave ]]
   short_name = case_name

--- a/tests/integration/test_bash_generation.py
+++ b/tests/integration/test_bash_generation.py
@@ -9,11 +9,11 @@ class TestBashGeneration(unittest.TestCase):
         )
         self.assertEqual(
             os.system(
-                "diff -bur test_output/post/scripts /lcrc/group/e3sm/public_html/zppy_test_resources/expected_bash_files"
+                "diff -bur test_bash_generation_output/post/scripts /lcrc/group/e3sm/public_html/zppy_test_resources/expected_bash_files"
             ),
             0,
         )
-        self.assertEqual(os.system("rm -r test_output"), 0)
+        self.assertEqual(os.system("rm -r test_bash_generation_output"), 0)
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_complete_run.cfg
+++ b/tests/integration/test_complete_run.cfg
@@ -2,13 +2,14 @@
 input = /lcrc/group/e3sm/ac.forsyth2/E3SM_simulations/20210122.v2_test01.piControl.ne30pg2_EC30to60E2r2-1900_ICG.chrysalis
 input_subdir = archive/atm/hist
 # To run this test, edit `output` and `www` in this file, along with `actual_images_dir` in test_complete_run.py
-output = /lcrc/group/e3sm/ac.forsyth2/zppy_test_output/20210122.v2_test01.piControl.ne30pg2_EC30to60E2r2-1900_ICG.chrysalis
+output = /lcrc/group/e3sm/ac.forsyth2/zppy_test_complete_run_output/20210122.v2_test01.piControl.ne30pg2_EC30to60E2r2-1900_ICG.chrysalis
 case = 20210122.v2_test01.piControl.ne30pg2_EC30to60E2r2-1900_ICG.chrysalis
-www = /lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_test_www
+www = /lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_test_complete_run_www
 e3sm_unified = latest
 partition = compute
 ref_start_yr = 1979
 ref_final_yr = 2016
+environment_commands = "source /lcrc/soft/climate/e3sm-unified/load_latest_e3sm_unified_chrysalis.sh"
 
 [climo]
 active = True
@@ -62,8 +63,7 @@ years = "1:100:10",
 active = True
 years = "1:20:20", "1:50:50",
 ts_num_years = 10
-sets = "lat_lon","zonal_mean_xy","zonal_mean_2d","polar","cosp_histogram","meridional_mean_2d","enso_diags","area_mean_time_series","diurnal_cycle",
-#"qbo" with 50 years requires the latest E3SM Diags
+# Currently using default `sets`
 
   [[ atm_monthly_180x360_aave ]]
   short_name = '20210122.v2_test01.piControl.ne30pg2_EC30to60E2r2-1900_ICG.chrysalis'

--- a/tests/integration/test_complete_run.py
+++ b/tests/integration/test_complete_run.py
@@ -71,11 +71,8 @@ def compare_images(
 
 class TestCompleteRun(unittest.TestCase):
     def test_complete_run(self):
-        # Run the following lines prior to running this test!!!
-        # `rm -rf /lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_test_www/20210122.v2_test01.piControl.ne30pg2_EC30to60E2r2-1900_ICG.chrysalis`
-        # `rm -rf /lcrc/group/e3sm/ac.forsyth2/zppy_test_output/20210122.v2_test01.piControl.ne30pg2_EC30to60E2r2-1900_ICG.chrysalis/post`
-        # `zppy -c tests/integration/test_complete_run.cfg`
-        actual_images_dir = "/lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_test_www/20210122.v2_test01.piControl.ne30pg2_EC30to60E2r2-1900_ICG.chrysalis"
+        # See docs/source/dev_guide/testing.rst for steps to run before running this test.
+        actual_images_dir = "/lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_test_complete_run_www/20210122.v2_test01.piControl.ne30pg2_EC30to60E2r2-1900_ICG.chrysalis"
 
         # The expected_images_file lists all images we expect to compare.
         expected_images_file = "/lcrc/group/e3sm/public_html/zppy_test_resources/image_list_expected_complete_run.txt"

--- a/tests/integration/test_environment_commands.cfg
+++ b/tests/integration/test_environment_commands.cfg
@@ -2,13 +2,14 @@
 input = /lcrc/group/e3sm/ac.forsyth2/E3SM_simulations/20210122.v2_test01.piControl.ne30pg2_EC30to60E2r2-1900_ICG.chrysalis
 input_subdir = archive/atm/hist
 # To run this test, edit `output` and `www` in this file, along with `actual_images_dir` in test_environment_commands.py
-output = /lcrc/group/e3sm/ac.forsyth2/zppy_test_output_environment_commands/20210122.v2_test01.piControl.ne30pg2_EC30to60E2r2-1900_ICG.chrysalis
+output = /lcrc/group/e3sm/ac.forsyth2/zppy_test_environment_commands_output/20210122.v2_test01.piControl.ne30pg2_EC30to60E2r2-1900_ICG.chrysalis
 case = 20210122.v2_test01.piControl.ne30pg2_EC30to60E2r2-1900_ICG.chrysalis
-www = /lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_test_www_environment_commands
+www = /lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_test_environment_commands_www
 e3sm_unified = latest
 partition = compute
 ref_start_yr = 1979
 ref_final_yr = 2016
+environment_commands = "source /lcrc/soft/climate/e3sm-unified/load_latest_e3sm_unified_chrysalis.sh"
 
 [climo]
 active = True
@@ -34,6 +35,7 @@ years = "1:50:10",
 active = True
 years = "1:20:20", "1:50:50",
 ts_num_years = 10
+# Just testing one set using alternative environment
 sets = "qbo",
 environment_commands="source /home/ac.forsyth2/miniconda3/etc/profile.d/conda.sh; conda activate e3sm_diags_env_dev"
 

--- a/tests/integration/test_environment_commands.py
+++ b/tests/integration/test_environment_commands.py
@@ -71,8 +71,8 @@ def compare_images(
 
 class TestEnvironmentCommands(unittest.TestCase):
     def test_environment_commands(self):
-        # Run `zppy -c test_environment_commands.cfg` prior to running this test!!!
-        actual_images_dir = "/lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_test_www_environment_commands/20210122.v2_test01.piControl.ne30pg2_EC30to60E2r2-1900_ICG.chrysalis"
+        # See docs/source/dev_guide/testing.rst for steps to run before running this test.
+        actual_images_dir = "/lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_test_environment_commands_www/20210122.v2_test01.piControl.ne30pg2_EC30to60E2r2-1900_ICG.chrysalis"
 
         # The expected_images_file lists all images we expect to compare.
         expected_images_file = "/lcrc/group/e3sm/public_html/zppy_test_resources/image_list_expected_environment_commands.txt"


### PR DESCRIPTION
Update E3SM Diags testing

-  `qbo` can now be tested with the latest E3SM Unified environment (https://github.com/E3SM-Project/e3sm_diags/issues/412 was addressed with https://github.com/E3SM-Project/e3sm_diags/pull/414 and included in the latest E3SM Unified release)
- `annual_cycle_zonal_mean` needs to be tested (#62, #108, #110).

