### PR TITLE
Explain environment_commands

### DIFF
--- a/_build/html/v1.0.0/getting_started.html
+++ b/_build/html/v1.0.0/getting_started.html
@@ -184,7 +184,7 @@
   <div class="section" id="getting-started">
 <span id="id1"></span><h1>Getting started<a class="headerlink" href="#getting-started" title="Permalink to this headline">¶</a></h1>
 <div class="section" id="activate-e3sm-unified-environment">
-<h2>Activate e3sm_unified environment<a class="headerlink" href="#activate-e3sm-unified-environment" title="Permalink to this headline">¶</a></h2>
+<span id="activate"></span><h2>Activate e3sm_unified environment<a class="headerlink" href="#activate-e3sm-unified-environment" title="Permalink to this headline">¶</a></h2>
 <p>If you have an account on one of the E3SM supported machines (NERSC, Compy, Acme1,
 LCRC, Cooley, Rhea), you can access <code class="docutils literal notranslate"><span class="pre">zppy</span></code> by activating <code class="docutils literal notranslate"><span class="pre">e3sm_unified</span></code>, which is
 a conda environment that pulls together Python and other E3SM tools such as

--- a/_build/html/v1.0.0/parameters.html
+++ b/_build/html/v1.0.0/parameters.html
@@ -200,6 +200,11 @@ types and default values for the parameters.</p>
 <span class="n">e3sm_unified</span> <span class="o">=</span> <span class="n">option</span><span class="p">(</span><span class="s1">&#39;latest&#39;</span><span class="p">,</span> <span class="s1">&#39;test&#39;</span><span class="p">,</span> <span class="n">default</span><span class="o">=</span><span class="s1">&#39;latest&#39;</span><span class="p">)</span>
 <span class="c1"># This should be set to True if you don&#39;t want the batch jobs to be submitted</span>
 <span class="n">dry_run</span> <span class="o">=</span> <span class="n">boolean</span><span class="p">(</span><span class="n">default</span><span class="o">=</span><span class="kc">False</span><span class="p">)</span>
+<span class="c1"># The following parameter is not defined in `default.ini`</span>
+<span class="c1"># Set up the environment -- this is where you can tell zppy to use a custom conda environment.</span>
+<span class="c1"># To use a custom conda environment, you can set `environment_commands=&quot;source &lt;path to conda.sh&gt;; conda activate &lt;custom environment&gt;&quot;`.</span>
+<span class="n">environment_commands</span> <span class="o">=</span> <span class="n">string</span>
+
 
 <span class="p">[</span><span class="n">climo</span><span class="p">]</span>
 <span class="c1"># Set to True to run this section</span>
@@ -357,6 +362,9 @@ types and default values for the parameters.</p>
 <span class="n">stream_ocn</span> <span class="o">=</span> <span class="n">string</span><span class="p">(</span><span class="n">default</span><span class="o">=</span><span class="s2">&quot;streams.ocean&quot;</span><span class="p">)</span>
 <span class="n">stream_ice</span> <span class="o">=</span> <span class="n">string</span><span class="p">(</span><span class="n">default</span><span class="o">=</span><span class="s2">&quot;streams.seaice&quot;</span><span class="p">)</span>
 <span class="n">generate</span> <span class="o">=</span> <span class="n">string_list</span><span class="p">(</span><span class="n">default</span><span class="o">=</span><span class="nb">list</span><span class="p">(</span><span class="s1">&#39;all&#39;</span><span class="p">,</span> <span class="s1">&#39;no_landIceCavities&#39;</span><span class="p">,</span> <span class="s1">&#39;no_BGC&#39;</span><span class="p">,</span> <span class="s1">&#39;no_icebergs&#39;</span><span class="p">,</span> <span class="s1">&#39;no_min&#39;</span><span class="p">,</span> <span class="s1">&#39;no_max&#39;</span><span class="p">,</span> <span class="s1">&#39;no_sose&#39;</span><span class="p">,</span> <span class="s1">&#39;no_climatologyMapAntarcticMelt&#39;</span><span class="p">,</span> <span class="s1">&#39;no_regionalTSDiagrams&#39;</span><span class="p">,</span> <span class="s1">&#39;no_timeSeriesAntarcticMelt&#39;</span><span class="p">,</span> <span class="s1">&#39;no_timeSeriesOceanRegions&#39;</span><span class="p">,</span> <span class="s1">&#39;no_climatologyMapSose&#39;</span><span class="p">,</span> <span class="s1">&#39;no_woceTransects&#39;</span><span class="p">,</span> <span class="s1">&#39;no_soseTransects&#39;</span><span class="p">,</span> <span class="s1">&#39;no_geojsonTransects&#39;</span><span class="p">,</span> <span class="s1">&#39;no_oceanRegionalProfiles&#39;</span><span class="p">,</span> <span class="s1">&#39;no_hovmollerOceanRegions&#39;</span><span class="p">))</span>
+<span class="c1"># Note that `environment_commands` needs to be the same for all related runs of `mpas_analysis`.</span>
+<span class="c1"># For example, if years 1-50 are run using one environment and years 51-100 are run using another, MPAS-Analysis may fail.</span>
+
 
 <span class="p">[</span><span class="n">global_time_series</span><span class="p">]</span>
 <span class="c1"># Set to True to run this section</span>

--- a/_build/html/v1.0.0/tutorial.html
+++ b/_build/html/v1.0.0/tutorial.html
@@ -174,7 +174,9 @@
 must be changed for use on other machines. These include the paths for
 <code class="docutils literal notranslate"><span class="pre">input</span></code>, <code class="docutils literal notranslate"><span class="pre">output</span></code>, <code class="docutils literal notranslate"><span class="pre">www</span></code>, <code class="docutils literal notranslate"><span class="pre">mapping_file</span></code>, <code class="docutils literal notranslate"><span class="pre">reference_data_path</span></code>, <code class="docutils literal notranslate"><span class="pre">obs_ts</span></code>,
 and <code class="docutils literal notranslate"><span class="pre">dc_obs_climo</span></code>. Different machines also have different partition names, so
-<code class="docutils literal notranslate"><span class="pre">partition</span></code> may need to be changed as well.</p>
+<code class="docutils literal notranslate"><span class="pre">partition</span></code> may need to be changed as well. <code class="docutils literal notranslate"><span class="pre">environment_commands</span></code> must also be
+updated between machines – see <a class="reference internal" href="getting_started.html#activate"><span class="std std-ref">“Activate e3sm_unified environment”</span></a>.</p>
+
 <div class="section" id="example-1">
 <h2>Example 1<a class="headerlink" href="#example-1" title="Permalink to this headline">¶</a></h2>
 <p>Let’s say we want to post-process 100 years of an existing simulation.</p>
@@ -184,8 +186,8 @@ and <code class="docutils literal notranslate"><span class="pre">dc_obs_climo</s
 <span class="linenos">  3</span><span class="na">input_subdir</span> <span class="o">=</span> <span class="s">archive/atm/hist</span>
 <span class="linenos">  4</span><span class="na">output</span> <span class="o">=</span> <span class="s">&lt;output&gt;</span>
 <span class="linenos">  5</span><span class="na">case</span> <span class="o">=</span> <span class="s">20210122.v2_test01.piControl.ne30pg2_EC30to60E2r2-1900_ICG.chrysalis</span>
-<span class="linenos">  6</span><span class="na">www</span> <span class="o">=</span> <span class="s">&lt;wwww&gt;</span>
-<span class="linenos">  7</span><span class="na">e3sm_unified</span> <span class="o">=</span> <span class="s">latest</span>
+<span class="linenos">  6</span><span class="na">www</span> <span class="o">=</span> <span class="s">&lt;www&gt;</span>
+<span class="linenos">  7</span><span class="na">environment_commands</span> <span class="o">=</span> <span class="s">&quot;source /lcrc/soft/climate/e3sm-unified/load_latest_e3sm_unified_chrysalis.sh&quot;</span>
 <span class="linenos">  8</span><span class="na">partition</span> <span class="o">=</span> <span class="s">compute</span>
 <span class="linenos">  9</span>
 <span class="linenos"> 10</span><span class="c1"># Regridded atmosphere climatologies every 20 and 50 years</span>
@@ -316,7 +318,7 @@ the global time series plots will be visible online.</p>
 <span class="linenos"> 4</span><span class="na">output</span> <span class="o">=</span> <span class="s">&lt;output&gt;</span>
 <span class="linenos"> 5</span><span class="na">case</span> <span class="o">=</span> <span class="s">20210603.v2rc3c.piControl.northamericax4v1pg2_WC14to60E2r3.chrysalis</span>
 <span class="linenos"> 6</span><span class="na">www</span> <span class="o">=</span> <span class="s">&lt;www&gt;</span>
-<span class="linenos"> 7</span><span class="na">e3sm_unified</span> <span class="o">=</span> <span class="s">latest</span>
+<span class="linenos"> 7</span><span class="na">environment_commands</span> <span class="o">=</span> <span class="s">&quot;source /lcrc/soft/climate/e3sm-unified/load_latest_e3sm_unified_chrysalis.sh&quot;</span>
 <span class="linenos"> 8</span><span class="na">partition</span> <span class="o">=</span> <span class="s">debug</span>
 <span class="linenos"> 9</span>
 <span class="linenos">10</span><span class="k">[climo]</span>


### PR DESCRIPTION
Explain `environment_commands` further in the v1.0.0 docs. #113 enabled revisions to older docs. https://github.com/forsyth2/zppy/pull/2 shows the relevant changes in a concise form. #111 shows what happens if the docs are built from those changes and then compared to `gh-pages` -- many irrelevant lines also end up changed. This pull request only makes the relevant changes.

Note that some of these changes we may want in the `main` docs -- that will require a separate pull request to `main`. 