### PR TITLE
Update E3SM Unified paths

### DIFF
--- a/zppy/__main__.py
+++ b/zppy/__main__.py
@@ -58,29 +58,23 @@ def main():
     if tmp:
         if tmp.startswith("compy"):
             machine = "compy"
-            environment_commands = (
-                "source /share/apps/E3SM/conda_envs/load_{}_e3sm_unified.sh".format(
-                    config["default"]["e3sm_unified"]
-                )
+            environment_commands = "source /share/apps/E3SM/conda_envs/load_{}_e3sm_unified_compy.sh".format(
+                config["default"]["e3sm_unified"]
             )
         elif tmp.startswith("cori"):
             machine = "cori"
-            environment_commands = "source /global/cfs/cdirs/e3sm/software/anaconda_envs/load_{}_e3sm_unified.sh".format(
+            environment_commands = "source /global/cfs/cdirs/e3sm/software/anaconda_envs/load_{}_e3sm_unified_cori-haswell.sh".format(
                 config["default"]["e3sm_unified"]
             )
         elif tmp.startswith("blues"):
             machine = "anvil"
-            environment_commands = (
-                "source /lcrc/soft/climate/e3sm-unified/load_{}_e3sm_unified.sh".format(
-                    config["default"]["e3sm_unified"]
-                )
+            environment_commands = "source /lcrc/soft/climate/e3sm-unified/load_{}_e3sm_unified_anvil.sh".format(
+                config["default"]["e3sm_unified"]
             )
         elif tmp.startswith("chr"):
             machine = "chrysalis"
-            environment_commands = (
-                "source /lcrc/soft/climate/e3sm-unified/load_{}_e3sm_unified.sh".format(
-                    config["default"]["e3sm_unified"]
-                )
+            environment_commands = "source /lcrc/soft/climate/e3sm-unified/load_{}_e3sm_unified_chrysalis.sh".format(
+                config["default"]["e3sm_unified"]
             )
     config["default"]["machine"] = machine
     if "environment_commands" not in config["default"].keys():


### PR DESCRIPTION
Update E3SM Unified paths to be machine-specific. With this change, the user is no longer required to specify `environment_commands`.

This pull request makes the changes from #109, but as a single commit that passes the pre-commit checks.