### PR TITLE
Add campaign parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ zppy.egg-info/
 
 tests/integration/image_check_failures
 test_bash_generation_output
+*.cfg.txt
 
 # Sphinx documentation
 docs/_build/

--- a/docs/source/parameters.rst
+++ b/docs/source/parameters.rst
@@ -40,8 +40,8 @@ types and default values for the parameters. ::
         e3sm_unified = option('latest', 'test', default='latest')
         # This should be set to True if you don't want the batch jobs to be submitted
         dry_run = boolean(default=False)
-	# Specify which campaign you are running.
-	campaign = string(default="none")
+        # Specify which campaign you are running.
+        campaign = string(default="none")
         # The following parameter is not defined in `default.ini`
         # Set up the environment -- this is where you can tell zppy to use a custom conda environment.
         # To use a custom conda environment, you can set `environment_commands="source <path to conda.sh>; conda activate <custom environment>"`.

--- a/docs/source/parameters.rst
+++ b/docs/source/parameters.rst
@@ -40,6 +40,8 @@ types and default values for the parameters. ::
         e3sm_unified = option('latest', 'test', default='latest')
         # This should be set to True if you don't want the batch jobs to be submitted
         dry_run = boolean(default=False)
+	# Specify which campaign you are running.
+	campaign = string(default="none")
         # The following parameter is not defined in `default.ini`
         # Set up the environment -- this is where you can tell zppy to use a custom conda environment.
         # To use a custom conda environment, you can set `environment_commands="source <path to conda.sh>; conda activate <custom environment>"`.

--- a/docs/source/post.mysimulation.cfg
+++ b/docs/source/post.mysimulation.cfg
@@ -6,6 +6,7 @@ case = 20210122.v2_test01.piControl.ne30pg2_EC30to60E2r2-1900_ICG.chrysalis
 www = <www>
 e3sm_unified = latest
 partition = compute
+campaign = "water_cycle"
 
 # Regridded atmosphere climatologies every 20 and 50 years
 [climo]

--- a/docs/source/post.rrm_simulation.cfg
+++ b/docs/source/post.rrm_simulation.cfg
@@ -6,6 +6,7 @@ case = 20210603.v2rc3c.piControl.northamericax4v1pg2_WC14to60E2r3.chrysalis
 www = <www>
 e3sm_unified = latest
 partition = debug
+campaign = "water_cycle"
 
 [climo]
 active = True

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -41,6 +41,14 @@ Post-processing results will be located in ``output`` and ``www``. Some machines
 a web server. ``www`` should be pointed to that so that E3SM Diags, MPAS-Analysis, and
 the global time series plots will be visible online.
 
+Because we have specified ``campaign = "water_cycle"``, some parameters will
+be automatically set. ``zppy/templates/water_cycle.cfg`` specifies what
+``[e3sm_diags] > sets``, ``[e3sm_diags_vs_model] > sets``, and
+``[mpas_analysis] > generate`` should be for the water cycle campaign.
+Users may specify their own values for any of these parameters,
+allowing for easy configuration changes. For example, a user could set
+``campaign = "water_cycle"`` but specify their own value for ``[e3sm_diags] > sets``.
+
 Example 2
 =========
 

--- a/tests/test_sections.py
+++ b/tests/test_sections.py
@@ -1,4 +1,5 @@
 import os
+import pprint
 import unittest
 
 from configobj import ConfigObj
@@ -20,6 +21,14 @@ def get_config(test_case, config_file):
     # Add templateDir to config
     config["default"]["templateDir"] = templateDir
 
+    # For debugging
+    DISPLAY_CONFIG = False
+    if DISPLAY_CONFIG:
+        with open("{}.txt".format(config_file), "w") as output:
+            p = pprint.PrettyPrinter(indent=2, stream=output)
+            p.pprint(config)
+        test_case.maxDiff = None
+
     return config
 
 
@@ -39,6 +48,7 @@ class TestAllSets(unittest.TestCase):
             "debug": False,
             "e3sm_unified": "latest",
             "dry_run": False,
+            "campaign": "none",
             "templateDir": "zppy/templates",
         }
         self.assertEqual(actual_default, expected_default)
@@ -69,6 +79,7 @@ class TestAllSets(unittest.TestCase):
         expected_task = {
             "active": True,
             "area_nm": "area",
+            "campaign": "none",
             "case": "CASE",
             "debug": False,
             "dpf": 30,
@@ -117,6 +128,7 @@ class TestAllSets(unittest.TestCase):
         actual_task = actual_tasks[0]
         expected_task = {
             "active": True,
+            "campaign": "none",
             "case": "CASE",
             "debug": False,
             "dry_run": False,
@@ -156,6 +168,7 @@ class TestAllSets(unittest.TestCase):
             "debug": False,
             "e3sm_unified": "latest",
             "dry_run": False,
+            "campaign": "none",
             "templateDir": "zppy/templates",
         }
         self.assertEqual(actual_default, expected_default)
@@ -218,6 +231,7 @@ class TestAllSets(unittest.TestCase):
         expected_task = {
             "active": True,
             "area_nm": "area",
+            "campaign": "none",
             "case": "CASE",
             "debug": False,
             "dpf": 30,
@@ -247,6 +261,7 @@ class TestAllSets(unittest.TestCase):
         expected_task = {
             "active": True,
             "area_nm": "area",
+            "campaign": "none",
             "case": "CASE",
             "debug": False,
             "dpf": 30,
@@ -322,6 +337,7 @@ class TestAllSets(unittest.TestCase):
         actual_task = actual_tasks[0]
         expected_task = {
             "active": True,
+            "campaign": "none",
             "case": "CASE",
             "debug": False,
             "dry_run": False,
@@ -348,6 +364,7 @@ class TestAllSets(unittest.TestCase):
         actual_task = actual_tasks[1]
         expected_task = {
             "active": True,
+            "campaign": "none",
             "case": "CASE",
             "debug": False,
             "dry_run": False,

--- a/zppy/__main__.py
+++ b/zppy/__main__.py
@@ -31,6 +31,7 @@ def main():
     # Read configuration file and validate it
     default_config = os.path.join(templateDir, "default.ini")
     user_config = ConfigObj(args.config, configspec=default_config)
+    _validate_config(user_config)
     campaign = user_config["default"]["campaign"]
     if campaign != "custom":
         campaign_file = os.path.join(templateDir, "{}.cfg".format(campaign))
@@ -39,20 +40,12 @@ def main():
                 "{} does not appear to be a known campaign".format(campaign)
             )
         config = ConfigObj(campaign_file, configspec=default_config)
+        _validate_config(config)
         # merge such that user_config takes priority
         config.merge(user_config)
     else:
         # no need to merge
         config = user_config
-
-    validator = Validator()
-
-    result = config.validate(validator)
-    if result is not True:
-        print("Validation results={}".format(result))
-        raise Exception("Configuration file validation failed")
-    else:
-        print("Configuration file validation passed")
 
     # Add templateDir to config
     config["default"]["templateDir"] = templateDir
@@ -115,3 +108,14 @@ def main():
 
     # global time series tasks
     global_time_series(config, scriptDir)
+
+
+def _validate_config(config):
+    validator = Validator()
+
+    result = config.validate(validator)
+    if result is not True:
+        print("Validation results={}".format(result))
+        raise Exception("Configuration file validation failed")
+    else:
+        print("Configuration file validation passed")

--- a/zppy/__main__.py
+++ b/zppy/__main__.py
@@ -29,7 +29,22 @@ def main():
     templateDir = os.path.join(os.path.dirname(__file__), "templates")
 
     # Read configuration file and validate it
-    config = ConfigObj(args.config, configspec=os.path.join(templateDir, "default.ini"))
+    default_config = os.path.join(templateDir, "default.ini")
+    user_config = ConfigObj(args.config, configspec=default_config)
+    campaign = user_config["default"]["campaign"]
+    if campaign != "custom":
+        campaign_file = os.path.join(templateDir, "{}.cfg".format(campaign))
+        if not os.path.exists(campaign_file):
+            raise ValueError(
+                "{} does not appear to be a known campaign".format(campaign)
+            )
+        config = ConfigObj(campaign_file, configspec=default_config)
+        # merge such that user_config takes priority
+        config.merge(user_config)
+    else:
+        # no need to merge
+        config = user_config
+
     validator = Validator()
 
     result = config.validate(validator)

--- a/zppy/__main__.py
+++ b/zppy/__main__.py
@@ -33,7 +33,7 @@ def main():
     user_config = ConfigObj(args.config, configspec=default_config)
     _validate_config(user_config)
     campaign = user_config["default"]["campaign"]
-    if campaign != "custom":
+    if campaign != "none":
         campaign_file = os.path.join(templateDir, "{}.cfg".format(campaign))
         if not os.path.exists(campaign_file):
             raise ValueError(

--- a/zppy/templates/default.ini
+++ b/zppy/templates/default.ini
@@ -8,7 +8,7 @@ debug = boolean(default=False)
 partition = string(default="")
 e3sm_unified = option('latest', 'test', default='latest')
 dry_run = boolean(default=False)
-campaign = string(default="custom")
+campaign = string(default="none")
 
 [climo]
 active = boolean(default=True)

--- a/zppy/templates/default.ini
+++ b/zppy/templates/default.ini
@@ -8,6 +8,7 @@ debug = boolean(default=False)
 partition = string(default="")
 e3sm_unified = option('latest', 'test', default='latest')
 dry_run = boolean(default=False)
+campaign = string(default="custom")
 
 [climo]
 active = boolean(default=True)

--- a/zppy/templates/water_cycle.cfg
+++ b/zppy/templates/water_cycle.cfg
@@ -1,0 +1,8 @@
+[e3sm_diags]
+sets = "lat_lon","zonal_mean_xy","zonal_mean_2d","polar","cosp_histogram","meridional_mean_2d","enso_diags","qbo","diurnal_cycle","annual_cycle_zonal_mean","streamflow"
+
+[e3sm_diags_vs_model]
+sets = "lat_lon","zonal_mean_xy","zonal_mean_2d","polar","cosp_histogram","meridional_mean_2d"
+
+[mpas_analysis]
+generate = 'all', 'no_landIceCavities', 'no_BGC', 'no_icebergs', 'no_min', 'no_max', 'no_sose', 'no_climatologyMapAntarcticMelt', 'no_regionalTSDiagrams', 'no_timeSeriesAntarcticMelt', 'no_timeSeriesOceanRegions', 'no_climatologyMapSose', 'no_woceTransects', 'no_soseTransects', 'no_geojsonTransects', 'no_oceanRegionalProfiles', 'no_hovmollerOceanRegions'


### PR DESCRIPTION
This merge adds a new "campaign" parameter to the "defaults" section that is "custom" by default.  For other values (currently only "water_cycle"), a config file is loaded with alternative default parameters.  The campaign parameters take priority over the defaults but the user parameters take priority over the campaign parameters. Thus, a user could set the campaign to "water_cycle" but still modify the set of analyses to run (e.g. for debugging).

closes #135