### PR TITLE
Ignore templateDir in tests

### DIFF
--- a/tests/integration/test_bash_generation.py
+++ b/tests/integration/test_bash_generation.py
@@ -9,7 +9,7 @@ class TestBashGeneration(unittest.TestCase):
         )
         self.assertEqual(
             os.system(
-                "diff -bur test_bash_generation_output/post/scripts /lcrc/group/e3sm/public_html/zppy_test_resources/expected_bash_files"
+                "diff -bur -I 'templateDir' test_bash_generation_output/post/scripts /lcrc/group/e3sm/public_html/zppy_test_resources/expected_bash_files"
             ),
             0,
         )

--- a/tests/integration/test_campaign.py
+++ b/tests/integration/test_campaign.py
@@ -12,7 +12,7 @@ class TestCampaign(unittest.TestCase):
         )
         self.assertEqual(
             os.system(
-                "diff -u test_campaign_cryosphere_output/post/scripts /lcrc/group/e3sm/public_html/zppy_test_resources/test_campaign_cryosphere_expected_files"
+                "diff -u -I 'templateDir' test_campaign_cryosphere_output/post/scripts /lcrc/group/e3sm/public_html/zppy_test_resources/test_campaign_cryosphere_expected_files"
             ),
             0,
         )
@@ -33,7 +33,7 @@ class TestCampaign(unittest.TestCase):
         )
         self.assertEqual(
             os.system(
-                "diff -u test_campaign_cryosphere_override_output/post/scripts /lcrc/group/e3sm/public_html/zppy_test_resources/test_campaign_cryosphere_override_expected_files"
+                "diff -u -I 'templateDir' test_campaign_cryosphere_override_output/post/scripts /lcrc/group/e3sm/public_html/zppy_test_resources/test_campaign_cryosphere_override_expected_files"
             ),
             0,
         )
@@ -48,7 +48,7 @@ class TestCampaign(unittest.TestCase):
         )
         self.assertEqual(
             os.system(
-                "diff -u test_campaign_none_output/post/scripts /lcrc/group/e3sm/public_html/zppy_test_resources/test_campaign_none_expected_files"
+                "diff -u -I 'templateDir' test_campaign_none_output/post/scripts /lcrc/group/e3sm/public_html/zppy_test_resources/test_campaign_none_expected_files"
             ),
             0,
         )
@@ -63,7 +63,7 @@ class TestCampaign(unittest.TestCase):
         )
         self.assertEqual(
             os.system(
-                "diff -u test_campaign_water_cycle_output/post/scripts /lcrc/group/e3sm/public_html/zppy_test_resources/test_campaign_water_cycle_expected_files"
+                "diff -u -I 'templateDir' test_campaign_water_cycle_output/post/scripts /lcrc/group/e3sm/public_html/zppy_test_resources/test_campaign_water_cycle_expected_files"
             ),
             0,
         )
@@ -84,7 +84,7 @@ class TestCampaign(unittest.TestCase):
         )
         self.assertEqual(
             os.system(
-                "diff -u test_campaign_water_cycle_override_output/post/scripts /lcrc/group/e3sm/public_html/zppy_test_resources/test_campaign_water_cycle_override_expected_files"
+                "diff -u -I 'templateDir' test_campaign_water_cycle_override_output/post/scripts /lcrc/group/e3sm/public_html/zppy_test_resources/test_campaign_water_cycle_override_expected_files"
             ),
             0,
         )


### PR DESCRIPTION
Ignore `templateDir` in tests. This means expected files won't have to be updated because someone else is running the tests or because a different conda environment is being used.