### PR TITLE
Fix timeout of conda build caused by Python version 3.10.0

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -18,10 +18,10 @@ build:
 
 requirements:
   host:
-    - python >=3.6
+    - python >=3.6,<=3.9
     - pip
   run:
-    - python >=3.6
+    - python >=3.6,<=3.9
     - configobj >=5.0.0,<6.0.0
     - jinja2 >=2.0.0,<3.0.0
 
@@ -33,8 +33,8 @@ test:
   commands:
     - zppy --help
     - pip check
-
 about:
+
   home: https://github.com/E3SM-Project/zppy
   license: BSD-3-Clause
   license_family: BSD


### PR DESCRIPTION
- Closes #154 
- Related failing workflow: https://github.com/E3SM-Project/zppy/runs/3901168476?check_suite_focus=true

Multiple of these errors are listed before timing out:
```
WARNING:conda.models.version:Using .* with relational operator is superfluous and deprecated and will be removed in a future version of conda. Your spec was 1.*, but conda is ignoring the .* and treating it as 1
```

## Debugging steps

1. Created conda enviornment and `release_workflow.yml` steps locally
```
conda create -n zppy_publish
conda activate zppy_publish

# From release_workflow.yml
conda install anaconda-client conda-build conda-verify
conda config --set anaconda_upload no
conda build -c conda-forge --output-folder . .
```
2. Generate full traceback
```
vo13@ml-9704174 zppy % conda activate zppy_publish
(zppy_publish) vo13@ml-9704174 zppy % conda build -c conda-forge --output-folder . .
No numpy version specified in conda_build_config.yaml.  Falling back to default numpy value of 1.16
WARNING:conda_build.metadata:No numpy version specified in conda_build_config.yaml.  Falling back to default numpy value of 1.16
Adding in variants from internal_defaults
INFO:conda_build.variants:Adding in variants from internal_defaults
Attempting to finalize metadata for zppy
INFO:conda_build.metadata:Attempting to finalize metadata for zppy
Collecting package metadata (repodata.json): ...working... done
Solving environment: ...working... done
Collecting package metadata (repodata.json): ...working... done
Solving environment: ...working... WARNING:conda.models.version:Using .* with relational operator is superfluous and deprecated and will be removed in a future version of conda. Your spec was 1.*, but conda is ignoring the .* and treating it as 1
WARNING conda.models.version:get_matcher(537): Using .* with relational operator is superfluous and deprecated and will be removed in a future version of conda. Your spec was 1.*, but conda is ignoring the .* and treating it as 1
WARNING:conda.models.version:Using .* with relational operator is superfluous and deprecated and will be removed in a future version of conda. Your spec was 2.*, but conda is ignoring the .* and treating it as 2
WARNING conda.models.version:get_matcher(537): Using .* with relational operator is superfluous and deprecated and will be removed in a future version of conda. Your spec was 2.*, but conda is ignoring the .* and treating it as 2
WARNING:conda.models.version:Using .* with relational operator is superfluous and deprecated and will be removed in a future version of conda. Your spec was 3.*, but conda is ignoring the .* and treating it as 3
WARNING conda.models.version:get_matcher(537): Using .* with relational operator is superfluous and deprecated and will be removed in a future version of conda. Your spec was 3.*, but conda is ignoring the .* and treating it as 3
WARNING:conda.models.version:Using .* with relational operator is superfluous and deprecated and will be removed in a future version of conda. Your spec was 2.*, but conda is ignoring the .* and treating it as 2
WARNING conda.models.version:get_matcher(537): Using .* with relational operator is superfluous and deprecated and will be removed in a future version of conda. Your spec was 2.*, but conda is ignoring the .* and treating it as 2
WARNING:conda.models.version:Using .* with relational operator is superfluous and deprecated and will be removed in a future version of conda. Your spec was 3.*, but conda is ignoring the .* and treating it as 3
WARNING conda.models.version:get_matcher(537): Using .* with relational operator is superfluous and deprecated and will be removed in a future version of conda. Your spec was 3.*, but conda is ignoring the .* and treating it as 3
WARNING:conda.models.version:Using .* with relational operator is superfluous and deprecated and will be removed in a future version of conda. Your spec was 4.*, but conda is ignoring the .* and treating it as 4
WARNING conda.models.version:get_matcher(537): Using .* with relational operator is superfluous and deprecated and will be removed in a future version of conda. Your spec was 4.*, but conda is ignoring the .* and treating it as 4
WARNING:conda.models.version:Using .* with relational operator is superfluous and deprecated and will be removed in a future version of conda. Your spec was 3.6.*, but conda is ignoring the .* and treating it as 3.6
WARNING conda.models.version:get_matcher(537): Using .* with relational operator is superfluous and deprecated and will be removed in a future version of conda. Your spec was 3.6.*, but conda is ignoring the .* and treating it as 3.6
WARNING:conda.models.version:Using .* with relational operator is superfluous and deprecated and will be removed in a future version of conda. Your spec was 0.23.*, but conda is ignoring the .* and treating it as 0.23
WARNING conda.models.version:get_matcher(537): Using .* with relational operator is superfluous and deprecated and will be removed in a future version of conda. Your spec was 0.23.*, but conda is ignoring the .* and treating it as 0.23
Found conflicts! Looking for incompatible packages.
This can take several minutes.  Press CTRL-C to abort.
failed
Leaving build/test directories:
  Work:
 /opt/miniconda3/conda-bld/work
  Test:
 /opt/miniconda3/conda-bld/test_tmp
Leaving build/test environments:
  Test:
source activate  /opt/miniconda3/conda-bld/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeho
  Build:
source activate  /opt/miniconda3/conda-bld/_build_env
Traceback (most recent call last):
  File "/opt/miniconda3/lib/python3.8/site-packages/conda_build/environ.py", line 802, in get_install_actions
    actions = install_actions(prefix, index, specs, force=True)
  File "/opt/miniconda3/lib/python3.8/site-packages/conda/common/io.py", line 88, in decorated
    return f(*args, **kwds)
  File "/opt/miniconda3/lib/python3.8/site-packages/conda/plan.py", line 474, in install_actions
    txn = solver.solve_for_transaction(prune=prune, ignore_pinned=not pinned)
  File "/opt/miniconda3/lib/python3.8/site-packages/conda/core/solve.py", line 114, in solve_for_transaction
    unlink_precs, link_precs = self.solve_for_diff(update_modifier, deps_modifier,
  File "/opt/miniconda3/lib/python3.8/site-packages/conda/core/solve.py", line 157, in solve_for_diff
    final_precs = self.solve_final_state(update_modifier, deps_modifier, prune, ignore_pinned,
  File "/opt/miniconda3/lib/python3.8/site-packages/conda/core/solve.py", line 281, in solve_final_state
    ssc = self._run_sat(ssc)
  File "/opt/miniconda3/lib/python3.8/site-packages/conda/common/io.py", line 88, in decorated
    return f(*args, **kwds)
  File "/opt/miniconda3/lib/python3.8/site-packages/conda/core/solve.py", line 815, in _run_sat
    ssc.solution_precs = ssc.r.solve(tuple(final_environment_specs),
  File "/opt/miniconda3/lib/python3.8/site-packages/conda/common/io.py", line 88, in decorated
    return f(*args, **kwds)
  File "/opt/miniconda3/lib/python3.8/site-packages/conda/resolve.py", line 1322, in solve
    self.find_conflicts(specs, specs_to_add, history_specs)
  File "/opt/miniconda3/lib/python3.8/site-packages/conda/resolve.py", line 352, in find_conflicts
    raise UnsatisfiableError(bad_deps, strict=strict_channel_priority)
conda.exceptions.UnsatisfiableError: The following specifications were found to be incompatible with each other:
Output in format: Requested package -> Available versions
Package tk conflicts for:
certifi==2021.5.30=py310hecd8cb5_0 -> python[version='>=3.10,<3.11.0a0'] -> tk[version='>=8.6.11,<8.7.0a0']
python==3.10.0=h38b4d05_2_cpython -> tk[version='>=8.6.11,<8.7.0a0']
pip==21.3=pyhd8ed1ab_0 -> python[version='>=3.6'] -> tk[version='8.5.*|8.6.*|>=8.6.10,<8.7.0a0|>=8.6.11,<8.7.0a0|>=8.6.9,<8.7.0a0|>=8.6.8,<8.7.0a0|>=8.6.7,<8.7.0a0']
tk==8.6.11=h5dbffcc_1
setuptools==58.0.4=py310hecd8cb5_0 -> python[version='>=3.10,<3.11.0a0'] -> tk[version='>=8.6.11,<8.7.0a0']
Package libcxx conflicts for:
libcxx==12.0.1=habf9029_0
python==3.10.0=h38b4d05_2_cpython -> libffi[version='>=3.4.2,<3.5.0a0'] -> libcxx[version='>=10.0.0|>=11.1.0|>=9.0.1|>=4.0.1']
libffi==3.4.2=he49afe7_4 -> libcxx[version='>=11.1.0']
readline==8.1=h05e3726_0 -> ncurses[version='>=6.2,<6.3.0a0'] -> libcxx[version='>=10.0.0|>=9.0.1|>=4.0.1']
sqlite==3.36.0=h23a322b_2 -> ncurses[version='>=6.2,<6.3.0a0'] -> libcxx[version='>=10.0.0|>=9.0.1|>=4.0.1']
pip==21.3=pyhd8ed1ab_0 -> python[version='>=3.6'] -> libcxx[version='>=10.0.0|>=10.0.1|>=11.0.0|>=11.0.1|>=11.1.0|>=9.0.1|>=9.0.0|>=4.0.1']
Package readline conflicts for:
certifi==2021.5.30=py310hecd8cb5_0 -> python[version='>=3.10,<3.11.0a0'] -> readline[version='>=8.0,<9.0a0|>=8.1,<9.0a0']
python==3.10.0=h38b4d05_2_cpython -> readline[version='>=8.1,<9.0a0']
python==3.10.0=h38b4d05_2_cpython -> sqlite[version='>=3.36.0,<4.0a0'] -> readline[version='>=8.0,<9.0a0']
setuptools==58.0.4=py310hecd8cb5_0 -> python[version='>=3.10,<3.11.0a0'] -> readline[version='>=8.0,<9.0a0|>=8.1,<9.0a0']
pip==21.3=pyhd8ed1ab_0 -> python[version='>=3.6'] -> readline[version='6.2.*|7.0|>=7.0,<8.0a0|>=8.0,<9.0a0|>=8.1,<9.0a0|7.*']
readline==8.1=h05e3726_0
sqlite==3.36.0=h23a322b_2 -> readline[version='>=8.1,<9.0a0']
Package libffi conflicts for:
python==3.10.0=h38b4d05_2_cpython -> libffi[version='>=3.4.2,<3.5.0a0']
certifi==2021.5.30=py310hecd8cb5_0 -> python[version='>=3.10,<3.11.0a0'] -> libffi[version='>=3.3,<3.4.0a0|>=3.4.2,<3.5.0a0']
setuptools==58.0.4=py310hecd8cb5_0 -> python[version='>=3.10,<3.11.0a0'] -> libffi[version='>=3.3,<3.4.0a0|>=3.4.2,<3.5.0a0']
libffi==3.4.2=he49afe7_4
pip==21.3=pyhd8ed1ab_0 -> python[version='>=3.6'] -> libffi[version='3.2.*|>=3.2.1,<3.3.0a0|>=3.3,<3.4.0a0|>=3.4.2,<3.5.0a0|>=3.2.1,<3.3a0']
Package ncurses conflicts for:
python==3.10.0=h38b4d05_2_cpython -> readline[version='>=8.1,<9.0a0'] -> ncurses[version='>=6.2,<7.0a0']
certifi==2021.5.30=py310hecd8cb5_0 -> python[version='>=3.10,<3.11.0a0'] -> ncurses[version='>=6.2,<6.3.0a0|>=6.2,<7.0a0']
ncurses==6.2=h2e338ed_4
sqlite==3.36.0=h23a322b_2 -> readline[version='>=8.1,<9.0a0'] -> ncurses[version='>=6.2,<7.0a0']
pip==21.3=pyhd8ed1ab_0 -> python[version='>=3.6'] -> ncurses[version='>=6.0,<7.0a0|>=6.1,<6.3.0a0|>=6.2,<6.3.0a0|>=6.2,<7.0a0|>=6.1,<7.0a0']
sqlite==3.36.0=h23a322b_2 -> ncurses[version='>=6.2,<6.3.0a0']
setuptools==58.0.4=py310hecd8cb5_0 -> python[version='>=3.10,<3.11.0a0'] -> ncurses[version='>=6.2,<6.3.0a0|>=6.2,<7.0a0']
python==3.10.0=h38b4d05_2_cpython -> ncurses[version='>=6.2,<6.3.0a0']
readline==8.1=h05e3726_0 -> ncurses[version='>=6.2,<6.3.0a0']
Package zlib conflicts for:
pip==21.3=pyhd8ed1ab_0 -> python[version='>=3.6'] -> zlib[version='1.2.*|1.2.11|>=1.2.11,<1.3.0a0|1.2.8']
zlib==1.2.11=h9173be1_1013
python==3.10.0=h38b4d05_2_cpython -> sqlite[version='>=3.36.0,<4.0a0'] -> zlib[version='>=1.2.11,<1.3.0a0']
certifi==2021.5.30=py310hecd8cb5_0 -> python[version='>=3.10,<3.11.0a0'] -> zlib[version='>=1.2.11,<1.3.0a0']
setuptools==58.0.4=py310hecd8cb5_0 -> python[version='>=3.10,<3.11.0a0'] -> zlib[version='>=1.2.11,<1.3.0a0']
sqlite==3.36.0=h23a322b_2 -> zlib[version='>=1.2.11,<1.3.0a0']
tk==8.6.11=h5dbffcc_1 -> zlib[version='>=1.2.11,<1.3.0a0']
Package bzip2 conflicts for:
bzip2==1.0.8=h0d85af4_4
python==3.10.0=h38b4d05_2_cpython -> bzip2[version='>=1.0.8,<2.0a0']
pip==21.3=pyhd8ed1ab_0 -> python[version='>=3.6'] -> bzip2[version='>=1.0.6,<2.0a0|>=1.0.8,<2.0a0']
setuptools==58.0.4=py310hecd8cb5_0 -> python[version='>=3.10,<3.11.0a0'] -> bzip2[version='>=1.0.8,<2.0a0']
certifi==2021.5.30=py310hecd8cb5_0 -> python[version='>=3.10,<3.11.0a0'] -> bzip2[version='>=1.0.8,<2.0a0']
Package libzlib conflicts for:
python==3.10.0=h38b4d05_2_cpython -> libzlib[version='>=1.2.11,<1.3.0a0']
sqlite==3.36.0=h23a322b_2 -> zlib[version='>=1.2.11,<1.3.0a0'] -> libzlib==1.2.11[build='h9173be1_1013|h9173be1_1012']
pip==21.3=pyhd8ed1ab_0 -> python[version='>=3.6'] -> libzlib[version='>=1.2.11,<1.3.0a0']
zlib==1.2.11=h9173be1_1013 -> libzlib==1.2.11=h9173be1_1013
libzlib==1.2.11=h9173be1_1013
tk==8.6.11=h5dbffcc_1 -> zlib[version='>=1.2.11,<1.3.0a0'] -> libzlib==1.2.11[build='h9173be1_1013|h9173be1_1012']
certifi==2021.5.30=py310hecd8cb5_0 -> python[version='>=3.10,<3.11.0a0'] -> libzlib[version='>=1.2.11,<1.3.0a0']
setuptools==58.0.4=py310hecd8cb5_0 -> python[version='>=3.10,<3.11.0a0'] -> libzlib[version='>=1.2.11,<1.3.0a0']
Package tzdata conflicts for:
tzdata==2021c=he74cb21_0
setuptools==58.0.4=py310hecd8cb5_0 -> python[version='>=3.10,<3.11.0a0'] -> tzdata
python==3.10.0=h38b4d05_2_cpython -> tzdata
pip==21.3=pyhd8ed1ab_0 -> python[version='>=3.6'] -> tzdata
certifi==2021.5.30=py310hecd8cb5_0 -> python[version='>=3.10,<3.11.0a0'] -> tzdata
Package setuptools conflicts for:
python==3.10.0=h38b4d05_2_cpython -> pip -> setuptools
setuptools==58.0.4=py310hecd8cb5_0
pip==21.3=pyhd8ed1ab_0 -> setuptools
Package pip conflicts for:
python==3.10.0=h38b4d05_2_cpython -> pip
pip==21.3=pyhd8ed1ab_0
certifi==2021.5.30=py310hecd8cb5_0 -> python[version='>=3.10,<3.11.0a0'] -> pip
setuptools==58.0.4=py310hecd8cb5_0 -> python[version='>=3.10,<3.11.0a0'] -> pip
Package pypy3.6 conflicts for:
wheel==0.37.0=pyhd8ed1ab_1 -> python[version='!=3.0,!=3.1,!=3.2,!=3.3,!=3.4'] -> pypy3.6[version='7.3.0.*|7.3.1.*|7.3.2.*|7.3.3.*']
pip==21.3=pyhd8ed1ab_0 -> python[version='>=3.6'] -> pypy3.6[version='7.3.0.*|7.3.1.*|7.3.2.*|7.3.3.*|>=7.3.3|>=7.3.2|>=7.3.1']
setuptools==58.0.4=py310hecd8cb5_0 -> certifi[version='>=2016.9.26'] -> pypy3.6[version='>=7.3.1|>=7.3.2|>=7.3.3']
Package openssl conflicts for:
setuptools==58.0.4=py310hecd8cb5_0 -> python[version='>=3.10,<3.11.0a0'] -> openssl[version='>=1.1.1l,<1.1.2a|>=3.0.0,<4.0a0']
certifi==2021.5.30=py310hecd8cb5_0 -> python[version='>=3.10,<3.11.0a0'] -> openssl[version='>=1.1.1l,<1.1.2a|>=3.0.0,<4.0a0']
pip==21.3=pyhd8ed1ab_0 -> python[version='>=3.6'] -> openssl[version='1.0.*|>=1.0.2o,<1.0.3a|>=1.0.2p,<1.0.3a|>=1.1.1a,<1.1.2a|>=1.1.1d,<1.1.2a|>=1.1.1e,<1.1.2a|>=1.1.1g,<1.1.2a|>=1.1.1h,<1.1.2a|>=1.1.1i,<1.1.2a|>=1.1.1j,<1.1.2a|>=1.1.1k,<1.1.2a|>=1.1.1l,<1.1.2a|>=3.0.0,<4.0a0|>=1.1.1f,<1.1.2a|>=1.1.1c,<1.1.2a|>=1.1.1b,<1.1.2a|>=1.0.2n,<1.0.3a|>=1.0.2m,<1.0.3a|>=1.0.2l,<1.0.3a']
python==3.10.0=h38b4d05_2_cpython -> openssl[version='>=3.0.0,<4.0a0']
openssl==3.0.0=h0d85af4_1
Package wheel conflicts for:
python==3.10.0=h38b4d05_2_cpython -> pip -> wheel
wheel==0.37.0=pyhd8ed1ab_1
pip==21.3=pyhd8ed1ab_0 -> wheel
Package certifi conflicts for:
setuptools==58.0.4=py310hecd8cb5_0 -> certifi[version='>=2016.9.26']
certifi==2021.5.30=py310hecd8cb5_0
pip==21.3=pyhd8ed1ab_0 -> setuptools -> certifi[version='>=2016.09|>=2016.9.26']
Package ca-certificates conflicts for:
openssl==3.0.0=h0d85af4_1 -> ca-certificates
python==3.10.0=h38b4d05_2_cpython -> openssl[version='>=3.0.0,<4.0a0'] -> ca-certificates
ca-certificates==2021.10.8=h033912b_0
Package xz conflicts for:
certifi==2021.5.30=py310hecd8cb5_0 -> python[version='>=3.10,<3.11.0a0'] -> xz[version='>=5.2.5,<5.3.0a0|>=5.2.5,<6.0a0']
pip==21.3=pyhd8ed1ab_0 -> python[version='>=3.6'] -> xz[version='5.2.*|>=5.2.3,<5.3.0a0|>=5.2.4,<5.3.0a0|>=5.2.5,<5.3.0a0|>=5.2.5,<6.0a0|>=5.2.4,<6.0a0|>=5.2.3,<6.0a0']
setuptools==58.0.4=py310hecd8cb5_0 -> python[version='>=3.10,<3.11.0a0'] -> xz[version='>=5.2.5,<5.3.0a0|>=5.2.5,<6.0a0']
xz==5.2.5=haf1e3a3_1
python==3.10.0=h38b4d05_2_cpython -> xz[version='>=5.2.5,<5.3.0a0']
Package sqlite conflicts for:
sqlite==3.36.0=h23a322b_2
certifi==2021.5.30=py310hecd8cb5_0 -> python[version='>=3.10,<3.11.0a0'] -> sqlite[version='>=3.36.0,<4.0a0']
pip==21.3=pyhd8ed1ab_0 -> python[version='>=3.6'] -> sqlite[version='3.13.*|3.20.*|>=3.24.0,<4.0a0|>=3.25.1,<4.0a0|>=3.25.2,<4.0a0|>=3.25.3,<4.0a0|>=3.26.0,<4.0a0|>=3.28.0,<4.0a0|>=3.30.1,<4.0a0|>=3.32.3,<4.0a0|>=3.33.0,<4.0a0|>=3.34.0,<4.0a0|>=3.35.5,<4.0a0|>=3.36.0,<4.0a0|>=3.35.4,<4.0a0|>=3.31.1,<4.0a0|>=3.30.0,<4.0a0|>=3.29.0,<4.0a0|>=3.27.2,<4.0a0|>=3.23.1,<4.0a0|>=3.22.0,<4.0a0|>=3.20.1,<4.0a0']
setuptools==58.0.4=py310hecd8cb5_0 -> python[version='>=3.10,<3.11.0a0'] -> sqlite[version='>=3.36.0,<4.0a0']
python==3.10.0=h38b4d05_2_cpython -> sqlite[version='>=3.36.0,<4.0a0']
Note that strict channel priority may have removed packages required for satisfiability.
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/opt/miniconda3/bin/conda-build", line 11, in <module>
    sys.exit(main())
  File "/opt/miniconda3/lib/python3.8/site-packages/conda_build/cli/main_build.py", line 481, in main
    execute(sys.argv[1:])
  File "/opt/miniconda3/lib/python3.8/site-packages/conda_build/cli/main_build.py", line 470, in execute
    outputs = api.build(args.recipe, post=args.post, test_run_post=args.test_run_post,
  File "/opt/miniconda3/lib/python3.8/site-packages/conda_build/api.py", line 186, in build
    return build_tree(
  File "/opt/miniconda3/lib/python3.8/site-packages/conda_build/build.py", line 3068, in build_tree
    packages_from_this = build(metadata, stats,
  File "/opt/miniconda3/lib/python3.8/site-packages/conda_build/build.py", line 2031, in build
    output_metas = expand_outputs([(m, need_source_download, need_reparse_in_env)])
  File "/opt/miniconda3/lib/python3.8/site-packages/conda_build/render.py", line 789, in expand_outputs
    for (output_dict, m) in deepcopy(_m).get_output_metadata_set(permit_unsatisfiable_variants=False):
  File "/opt/miniconda3/lib/python3.8/site-packages/conda_build/metadata.py", line 2115, in get_output_metadata_set
    conda_packages = finalize_outputs_pass(ref_metadata, conda_packages, pass_no=0,
  File "/opt/miniconda3/lib/python3.8/site-packages/conda_build/metadata.py", line 776, in finalize_outputs_pass
    fm = finalize_metadata(om, parent_metadata=parent_metadata,
  File "/opt/miniconda3/lib/python3.8/site-packages/conda_build/render.py", line 569, in finalize_metadata
    full_build_deps, _, _ = get_env_dependencies(m, pinning_env,
  File "/opt/miniconda3/lib/python3.8/site-packages/conda_build/render.py", line 139, in get_env_dependencies
    actions = environ.get_install_actions(tmpdir, tuple(dependencies), env,
  File "/opt/miniconda3/lib/python3.8/site-packages/conda_build/environ.py", line 804, in get_install_actions
    raise DependencyNeedsBuildingError(exc, subdir=subdir)
conda_build.exceptions.DependencyNeedsBuildingError: Unsatisfiable dependencies for platform osx-64: {"openssl[version='1.0.*|>=1.0.2o,<1.0.3a|>=1.0.2p,<1.0.3a|>=1.1.1a,<1.1.2a|>=1.1.1d,<1.1.2a|>=1.1.1e,<1.1.2a|>=1.1.1g,<1.1.2a|>=1.1.1h,<1.1.2a|>=1.1.1i,<1.1.2a|>=1.1.1j,<1.1.2a|>=1.1.1k,<1.1.2a|>=1.1.1l,<1.1.2a|>=3.0.0,<4.0a0|>=1.1.1f,<1.1.2a|>=1.1.1c,<1.1.2a|>=1.1.1b,<1.1.2a|>=1.0.2n,<1.0.3a|>=1.0.2m,<1.0.3a|>=1.0.2l,<1.0.3a']", "sqlite[version='3.13.*|3.20.*|>=3.24.0,<4.0a0|>=3.25.1,<4.0a0|>=3.25.2,<4.0a0|>=3.25.3,<4.0a0|>=3.26.0,<4.0a0|>=3.28.0,<4.0a0|>=3.30.1,<4.0a0|>=3.32.3,<4.0a0|>=3.33.0,<4.0a0|>=3.34.0,<4.0a0|>=3.35.5,<4.0a0|>=3.36.0,<4.0a0|>=3.35.4,<4.0a0|>=3.31.1,<4.0a0|>=3.30.0,<4.0a0|>=3.29.0,<4.0a0|>=3.27.2,<4.0a0|>=3.23.1,<4.0a0|>=3.22.0,<4.0a0|>=3.20.1,<4.0a0']", "ncurses[version='>=6.2,<6.3.0a0']", "openssl[version='>=3.0.0,<4.0a0']", "libcxx[version='>=10.0.0|>=11.1.0|>=9.0.1|>=4.0.1']", 'libzlib==1.2.11=h9173be1_1013', "bzip2[version='>=1.0.6,<2.0a0|>=1.0.8,<2.0a0']", "libzlib==1.2.11[build='h9173be1_1013|h9173be1_1012']", "ncurses[version='>=6.0,<7.0a0|>=6.1,<6.3.0a0|>=6.2,<6.3.0a0|>=6.2,<7.0a0|>=6.1,<7.0a0']", "readline[version='>=8.0,<9.0a0|>=8.1,<9.0a0']", "libcxx[version='>=11.1.0']", "libffi[version='3.2.*|>=3.2.1,<3.3.0a0|>=3.3,<3.4.0a0|>=3.4.2,<3.5.0a0|>=3.2.1,<3.3a0']", "readline[version='>=8.0,<9.0a0']", 'ca-certificates', "libffi[version='>=3.3,<3.4.0a0|>=3.4.2,<3.5.0a0']", "certifi[version='>=2016.09|>=2016.9.26']", 'tzdata', 'pip', "pypy3.6[version='7.3.0.*|7.3.1.*|7.3.2.*|7.3.3.*']", "tk[version='>=8.6.11,<8.7.0a0']", "certifi[version='>=2016.9.26']", 'setuptools', "libzlib[version='>=1.2.11,<1.3.0a0']", "pypy3.6[version='7.3.0.*|7.3.1.*|7.3.2.*|7.3.3.*|>=7.3.3|>=7.3.2|>=7.3.1']", "readline[version='>=8.1,<9.0a0']", "readline[version='6.2.*|7.0|>=7.0,<8.0a0|>=8.0,<9.0a0|>=8.1,<9.0a0|7.*']", "openssl[version='>=1.1.1l,<1.1.2a|>=3.0.0,<4.0a0']", "libcxx[version='>=10.0.0|>=9.0.1|>=4.0.1']", "libffi[version='>=3.4.2,<3.5.0a0']", "sqlite[version='>=3.36.0,<4.0a0']", "xz[version='>=5.2.5,<5.3.0a0|>=5.2.5,<6.0a0']", "bzip2[version='>=1.0.8,<2.0a0']", "ncurses[version='>=6.2,<7.0a0']", "tk[version='8.5.*|8.6.*|>=8.6.10,<8.7.0a0|>=8.6.11,<8.7.0a0|>=8.6.9,<8.7.0a0|>=8.6.8,<8.7.0a0|>=8.6.7,<8.7.0a0']", "ncurses[version='>=6.2,<6.3.0a0|>=6.2,<7.0a0']", "zlib[version='>=1.2.11,<1.3.0a0']", "xz[version='5.2.*|>=5.2.3,<5.3.0a0|>=5.2.4,<5.3.0a0|>=5.2.5,<5.3.0a0|>=5.2.5,<6.0a0|>=5.2.4,<6.0a0|>=5.2.3,<6.0a0']", 'wheel', "xz[version='>=5.2.5,<5.3.0a0']", "zlib[version='1.2.*|1.2.11|>=1.2.11,<1.3.0a0|1.2.8']", "libcxx[version='>=10.0.0|>=10.0.1|>=11.0.0|>=11.0.1|>=11.1.0|>=9.0.1|>=9.0.0|>=4.0.1']", "pypy3.6[version='>=7.3.1|>=7.3.2|>=7.3.3']"}
```

3. The log lists `python[version='>=3.10,<3.11.0a0']` on multiple lines of package conflict errors. I noticed conda-forge has 3.10.0 on their main channel label here: https://anaconda.org/conda-forge/python/labels, so it seems like this version is being installed alongside incompatible packages.

4. Updated `meta.yaml` with version range for Python

Before:
```
requirements:
  host:
    - python >=3.6
    - pip
  run:
    - python >=3.6
    - configobj >=5.0.0,<6.0.0
    - jinja2 >=2.0.0,<3.0.0
```

After:
```
requirements:
  host:
    - python >=3.6,<=3.9
    - pip
  run:
    - python >=3.6,<=3.9
    - configobj >=5.0.0,<6.0.0
    - jinja2 >=2.0.0,<3.0.0
```

5. Success
```
(zppy_publish) vo13@ml-9704174 zppy % conda build -c conda-forge --output-folder . .
No numpy version specified in conda_build_config.yaml.  Falling back to default numpy value of 1.16
WARNING:conda_build.metadata:No numpy version specified in conda_build_config.yaml.  Falling back to default numpy value of 1.16
Adding in variants from internal_defaults
INFO:conda_build.variants:Adding in variants from internal_defaults
Attempting to finalize metadata for zppy
INFO:conda_build.metadata:Attempting to finalize metadata for zppy
Collecting package metadata (repodata.json): ...working... done
Solving environment: ...working... done
Collecting package metadata (repodata.json): ...working... done
Solving environment: ...working... done
BUILD START: ['zppy-1.1.0rc2-py_0.tar.bz2']
Collecting package metadata (repodata.json): ...working... done
Solving environment: ...working... done

## Package Plan ##

  environment location: /opt/miniconda3/conda-bld/zppy_1634321817364/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_pla


The following NEW packages will be INSTALLED:

    ca-certificates: 2021.10.8-h033912b_0     conda-forge
    libcxx:          12.0.1-habf9029_0        conda-forge
    libffi:          3.3-h046ec9c_2           conda-forge
    libzlib:         1.2.11-h9173be1_1013     conda-forge
    ncurses:         6.2-h2e338ed_4           conda-forge
    openssl:         1.1.1l-h0d85af4_0        conda-forge
    pip:             21.3-pyhd8ed1ab_0        conda-forge
    python:          3.9.0-h4f09611_5_cpython conda-forge
    python_abi:      3.9-2_cp39               conda-forge
    readline:        8.1-h05e3726_0           conda-forge
    setuptools:      58.2.0-py39h6e9494a_0    conda-forge
    sqlite:          3.36.0-h23a322b_2        conda-forge
    tk:              8.6.11-h5dbffcc_1        conda-forge
    tzdata:          2021c-he74cb21_0         conda-forge
    wheel:           0.37.0-pyhd8ed1ab_1      conda-forge
    xz:              5.2.5-haf1e3a3_1         conda-forge
    zlib:            1.2.11-h9173be1_1013     conda-forge

Preparing transaction: ...working... done
Verifying transaction: ...working... done
Executing transaction: ...working... done
```