### PR TITLE
Add a template for high-res E3SM v1 runs 

### DIFF
--- a/zppy/templates/high_res_v1.cfg
+++ b/zppy/templates/high_res_v1.cfg
@@ -1,0 +1,13 @@
+[default]
+# make sure we load the Cori-Haswell environment
+partition = "haswell"
+
+[mpas_analysis]
+# Use the big-memory nodes on the amd parition (these require special access)
+qos = "bigmem"
+partition = "amd"
+parallelTaskCount = 16
+mapMpiTasks = 32
+generate = 'climatologyMapMLD', 'climatologyMapSST', 'climatologyMapSSS', 'climatologyMapSSH', 'climatologyMapEKE', 'climatologyMapWoa', 'climatologyMapArgoTemperature', 'climatologyMapArgoSalinity', 'woceTransects', 'timeSeriesSST', 'timeSeriesTransport', 'streamfunctionMOC', 'no_refYearMpasClimatologyOcean', 'climatologyMapSeaIceConcNH', 'climatologyMapSeaIceThickNH', 'climatologyMapSeaIceConcSH', 'climatologyMapSeaIceThickSH'
+mesh = "oRRS18to6v3"
+PostMOC = True


### PR DESCRIPTION
Currently, all config options are for MPAS-Analysis.