### PR TITLE
revise ncclimo calls

### DIFF
--- a/zppy/templates/climo.bash
+++ b/zppy/templates/climo.bash
@@ -27,8 +27,6 @@ cd ${workdir}
 ncclimo \
 --case={{ case }} \
 --jobs=${SLURM_NNODES} \
---mem_mb=0 \
---thr=1 \
 {%- if exclude %}
 -n '-x' \
 {%- endif %}
@@ -46,7 +44,7 @@ ncclimo \
 --output=trash \
 --regrid=output \
 {%- endif %}
---model={{ input_files.split(".")[0] }}
+--prc_typ={{ input_files.split(".")[0] }}
 
 {% elif frequency.startswith('diurnal') %}
 
@@ -89,8 +87,6 @@ ls {{ case }}.{{ input_files }}.????-*.nc > input.txt
 cat input.txt | ncclimo \
 --case={{ case }}.{{ input_files }} \
 --jobs=${SLURM_NNODES} \
---mem_mb=0 \
---thr=1 \
 {%- if exclude %}
 -n '-x' \
 {%- endif %}

--- a/zppy/templates/climo.bash
+++ b/zppy/templates/climo.bash
@@ -27,6 +27,7 @@ cd ${workdir}
 ncclimo \
 --case={{ case }} \
 --jobs=${SLURM_NNODES} \
+--thr=1 \
 {%- if exclude %}
 -n '-x' \
 {%- endif %}
@@ -44,7 +45,11 @@ ncclimo \
 --output=trash \
 --regrid=output \
 {%- endif %}
+{%- if input_files.split(".")[0] == 'cam' or input_files.split(".")[0] == 'eam'%}
 --prc_typ={{ input_files.split(".")[0] }}
+{%- else -%}
+--prc_typ=sgs
+{%- endif %}
 
 {% elif frequency.startswith('diurnal') %}
 
@@ -87,6 +92,7 @@ ls {{ case }}.{{ input_files }}.????-*.nc > input.txt
 cat input.txt | ncclimo \
 --case={{ case }}.{{ input_files }} \
 --jobs=${SLURM_NNODES} \
+--thr=1 \
 {%- if exclude %}
 -n '-x' \
 {%- endif %}

--- a/zppy/templates/ts.bash
+++ b/zppy/templates/ts.bash
@@ -73,7 +73,7 @@ cat input.txt | ncclimo \
 {%- elif mapping_file == 'glb' -%}
 -o output \
 --glb_avg \
---area_nm={{ area_nm }} \
+--area={{ area_nm }} \
 {%- else -%}
 --map={{ mapping_file }} \
 -o trash \
@@ -84,7 +84,13 @@ cat input.txt | ncclimo \
 --dpf={{ dpf }} \
 --tpd={{ tpd }} \
 {%- endif %}
+{%- if input_files.split(".")[0] == 'cam' or input_files.split(".")[0] == 'eam'%}
 --prc_typ={{ input_files.split(".")[0] }}
+{%- else -%}
+--prc_typ=sgs
+{%- endif %}
+
+
 
 if [ $? != 0 ]; then
   cd {{ scriptDir }}

--- a/zppy/templates/ts.bash
+++ b/zppy/templates/ts.bash
@@ -84,6 +84,7 @@ cat input.txt | ncclimo \
 --dpf={{ dpf }} \
 --tpd={{ tpd }} \
 {%- endif %}
+--prc_typ={{ input_files.split(".")[0] }}
 
 if [ $? != 0 ]; then
   cd {{ scriptDir }}


### PR DESCRIPTION
This PR closes #220 #165 
@czender Would you please help review this PR. 
In the metadata of newly generated land variable data, there is a new line in `history`: ncap2 -O -s area*=6.37122e6^2/1.0e6;area@long_name=\"Gridcell area\";area@units=\"km^2\" output/LAISUN_000101_002512.nc output/LAISUN_000101_002512.nc

Does this mean the sgs method is applied successful?

A separate question for e3sm2cmip. It's tricky to identify if sgs_frac is applied in cmorized time series. The early versions of land data has following in the global attribute: "
```
:ncclimo_generation_command = "ncclimo --var=${var} -7 --dfl_lvl=1 --no_cll_msr --no_frm_trm --no_stg_grd --yr_srt=1 --yr_end=500 --ypf=25 --map=map_ne30np4_to_cmip6_180x360_aave.20181001.nc " ;
:ncclimo_version = "4.8.1-alpha04""
```
But for newly cmorized data, there is no such history retained...and perhaps we can use one of the temperature variable (i.g. soil temperature) and it's temperature range as an indicator if sgs is applied?