### PR TITLE
Update package versions

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -30,10 +30,10 @@ jobs:
       - name: Checkout Code Repository
         uses: actions/checkout@v2
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       # Run all pre-commit hooks on all the files.
       # Getting only staged files can be tricky in case a new PR is opened
@@ -101,7 +101,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Cache pip
         uses: actions/cache@v2

--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -30,10 +30,10 @@ jobs:
       - name: Checkout Code Repository
         uses: actions/checkout@v2
 
-      - name: Set up Python 3.8
+      - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       # Run all pre-commit hooks on all the files.
       # Getting only staged files can be tricky in case a new PR is opened
@@ -101,7 +101,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Cache pip
         uses: actions/cache@v2
@@ -113,28 +113,33 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
             ${{ runner.os }}-
+
       # Using pip for Sphinx dependencies because it takes too long to reproduce a conda environment (~10 secs vs. 3-4 mins)
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install sphinx==4.0.2 sphinx_rtd_theme==0.5.2 sphinx-multiversion==0.2.4 docutils==0.16
+          pip install sphinx==5.2.3 sphinx_rtd_theme==1.0.0 sphinx-multiversion==0.2.4 docutils==0.16
       - name: Build Sphinx Docs
         run: |
           cd docs
           sphinx-multiversion source _build/html
+
       - name: Copy Docs and Commit
         run: |
           # gh-pages branch must already exist
           git clone https://github.com/E3SM-Project/zppy.git --branch gh-pages --single-branch gh-pages
+
           # Only replace main docs with latest changes. Docs for tags should be untouched.
           cd gh-pages
           rm -r _build/html/main
           cp -r ../docs/_build/html/main _build/html/main
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
+
           # The below command will fail if no changes were present, so we ignore it
           git add .
           git commit -m "Update documentation" -a || true
+
       - name: Push Changes
         uses: ad-m/github-push-action@master
         with:

--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           activate-environment: "zppy_publish"
           channel-priority: strict
-          python-version: 3.8
+          python-version: 3.9
           auto-update-conda: true
           # IMPORTANT: This needs to be set for caching to work properly!
           use-only-tar-bz2: true
@@ -70,7 +70,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Cache pip
         uses: actions/cache@v2
@@ -82,29 +82,36 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
             ${{ runner.os }}-
+
       # Using pip for Sphinx dependencies because it takes too long to reproduce a conda environment (~10 secs vs. 3-4 mins)
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install sphinx==4.0.2 sphinx_rtd_theme==0.5.2 sphinx-multiversion==0.2.4 docutils==0.16
+          pip install sphinx==5.2.3 sphinx_rtd_theme==1.0.0 sphinx-multiversion==0.2.4 docutils==0.16
+
       - name: Build Sphinx Docs
         run: |
           cd docs
           sphinx-multiversion source _build/html
+
       - name: Copy Docs and Commit
         run: |
           # gh-pages branch must already exist
           git clone https://github.com/E3SM-Project/zppy.git --branch gh-pages --single-branch gh-pages
           cd gh-pages
+
           # Replace main docs to populate dropdown with latest tags
           rm -r _build/html/main
+
           # Only copy docs for main and current tag
           cp -r -n ../docs/_build/html _build/
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
+
           # The below command will fail if no changes were present, so we ignore it
           git add .
           git commit -m "Update documentation" -a || true
+
       - name: Push Changes
         uses: ad-m/github-push-action@master
         with:

--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           activate-environment: "zppy_publish"
           channel-priority: strict
-          python-version: 3.7
+          python-version: 3.8
           auto-update-conda: true
           # IMPORTANT: This needs to be set for caching to work properly!
           use-only-tar-bz2: true
@@ -70,7 +70,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Cache pip
         uses: actions/cache@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ fail_fast: true
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.3.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -13,13 +13,13 @@ repos:
 
   # Can run individually with `pre-commit run black --all-files`
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.8.0
     hooks:
       - id: black
 
   # Can run individually with `pre-commit run isort --all-files`
   - repo: https://github.com/timothycrosley/isort
-    rev: 5.9.1
+    rev: 5.10.1
     hooks:
       - id: isort
 
@@ -27,7 +27,7 @@ repos:
   # Need to use flake8 GitHub mirror due to CentOS git issue with GitLab
   # https://github.com/pre-commit/pre-commit/issues/1206
   - repo: https://github.com/pycqa/flake8
-    rev: 3.9.2
+    rev: 5.0.4
     hooks:
       - id: flake8
         args: ["--config=setup.cfg"]
@@ -35,7 +35,7 @@ repos:
 
   # Can run individually with `pre-commit run mypy --all-files`
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.910
+    rev: v0.982
     hooks:
       - id: mypy
         args: ["--config=setup.cfg"]

--- a/conda/dev.yml
+++ b/conda/dev.yml
@@ -5,12 +5,12 @@ channels:
 dependencies:
   # Base
   # =================
+  - python=3.9.13
+  - pip=22.2.2
   - configobj=5.0.6
   - jinja2=3.1.2
   - mache>=1.5.0
   - pillow=9.2.0
-  - pip=22.2.2
-  - python=3.8.0
   # Developer Tools
   # =================
   # If versions are updated, also update 'rev' in `.pre-commit-config.yaml`
@@ -20,6 +20,7 @@ dependencies:
   - flake8-isort=4.2.0  # version from https://anaconda.org/conda-forge/flake8-isort
   - mypy=0.982          # version from https://anaconda.org/conda-forge/mypy
   - pre-commit=2.20.0   # version from https://anaconda.org/conda-forge/pre-commit
+  - tbump=6.9.0
   # Documentation
   # If versions are updated, also update in `.github/workflows/build_workflow.yml`
   # =================
@@ -30,5 +31,4 @@ dependencies:
   - docutils=0.16
   - pip:
       - sphinx-multiversion==0.2.4
-      - tbump==6.9.0
 prefix: /opt/miniconda3/envs/zppy_dev

--- a/conda/dev.yml
+++ b/conda/dev.yml
@@ -6,29 +6,29 @@ dependencies:
   # Base
   # =================
   - configobj=5.0.6
-  - jinja2=3.0.3
-  - mache >=1.3.2
-  - pillow=8.1.2
-  - pip=21.0.1
-  - python=3.7.10
+  - jinja2=3.1.2
+  - mache>=1.5.0
+  - pillow=9.2.0
+  - pip=22.2.2
+  - python=3.8.0
   # Developer Tools
   # =================
-  # If versions are updated, also update 'rev' in `.pre-commit.config.yaml`
-  - black=22.3.0        # version from https://anaconda.org/conda-forge/black
-  - flake8=3.9.2        # version from https://anaconda.org/conda-forge/flake8
+  # If versions are updated, also update 'rev' in `.pre-commit-config.yaml`
+  - black=22.8.0        # version from https://anaconda.org/conda-forge/black
+  - flake8=5.0.4        # version from https://anaconda.org/conda-forge/flake8
   # This line also implicitly installs isort
-  - flake8-isort=4.0.0  # version from https://anaconda.org/conda-forge/flake8-isort
-  - mypy=0.910          # version from https://anaconda.org/conda-forge/mypy
-  - pre-commit=2.13.0   # version from https://anaconda.org/conda-forge/pre-commit
+  - flake8-isort=4.2.0  # version from https://anaconda.org/conda-forge/flake8-isort
+  - mypy=0.982          # version from https://anaconda.org/conda-forge/mypy
+  - pre-commit=2.20.0   # version from https://anaconda.org/conda-forge/pre-commit
   # Documentation
-  # If versions are updated, also update in `.github/workflows/workflow.yml`
+  # If versions are updated, also update in `.github/workflows/build_workflow.yml`
   # =================
-  - sphinx=3.5.1
-  - sphinx_rtd_theme=0.5.1
+  - sphinx=5.2.3
+  - sphinx_rtd_theme=1.0.0
   # Need to pin docutils because 0.17 has a bug with unordered lists
   # https://github.com/readthedocs/sphinx_rtd_theme/issues/1115
   - docutils=0.16
   - pip:
       - sphinx-multiversion==0.2.4
-      - tbump==6.3.2
+      - tbump==6.9.0
 prefix: /opt/miniconda3/envs/zppy_dev

--- a/conda/dev.yml
+++ b/conda/dev.yml
@@ -6,7 +6,7 @@ dependencies:
   # Base
   # =================
   - configobj=5.0.6
-  - jinja2=3.1.2
+  - jinja2=3.0.3
   - mache >=1.3.2
   - pillow=8.1.2
   - pip=21.0.1


### PR DESCRIPTION
Change `jinja2` version. Resolves #318. Note that this does _not_ break #252, since the version is still above `3.0.0`. Also updates various other package versions.