### PR TITLE
Years fix

### DIFF
--- a/zppy/utils.py
+++ b/zppy/utils.py
@@ -95,7 +95,9 @@ def get_active_status(task):
 
 
 def getYears(years_list):
-
+    if type(years_list) == str:
+        # This will be the case if years_list is missing a trailing comma
+        years_list = [years_list]
     year_sets = []
     for years in years_list:
 


### PR DESCRIPTION
Workaround for missing comma in `years`.

Note that #281/#320 was intended to improve the error description from the validator. However, as reported in #319, the validator no longer warns of a missing comma. Therefore, it is simpler to just add this workaround.