### PR TITLE
add aerosol budget tables as a default set for e3sm_diags

### DIFF
--- a/zppy/templates/default.ini
+++ b/zppy/templates/default.ini
@@ -164,7 +164,7 @@ reference_data_path_ts_rof = string(default="")
 # Required for "model_vs_model" "enso_diags"/"streamflow"/"tc_analysis" runs: `ref_final_yr`, `ref_start_yr`
 run_type = string(default="model_vs_obs")
 # The sets to run
-# All available sets = "lat_lon","zonal_mean_xy","zonal_mean_2d","polar","cosp_histogram","meridional_mean_2d","enso_diags","qbo","diurnal_cycle","annual_cycle_zonal_mean","streamflow","zonal_mean_2d_stratosphere","tc_analysis","area_mean_time_series","aerosol_aeronet",
+# All available sets = "lat_lon","zonal_mean_xy","zonal_mean_2d","polar","cosp_histogram","meridional_mean_2d","enso_diags","qbo","diurnal_cycle","annual_cycle_zonal_mean","streamflow","zonal_mean_2d_stratosphere","tc_analysis","area_mean_time_series","aerosol_aeronet","aerosol_budget",
 # A subset of these are provided as a default. These sets can be run as long as standard climo files are generated.
 # The additional sets can be included if the appropriate input is available: "enso_diags","qbo","diurnal_cycle","streamflow","tc_analysis","area_mean_time_series"
 # Note that "enso_diags","qbo","area_mean_time_series" require time-series data.
@@ -173,7 +173,7 @@ run_type = string(default="model_vs_obs")
 # "diurnal_cycle" requires `climo_diurnal_subsection`, `climo_diurnal_frequency`, and `dc_obs_climo` to be set.
 # "streamflow" requires `streamflow_obs_ts` to be set.
 # "tc_analysis" requires `tc_obs` to be set.
-sets = string_list(default=list("lat_lon","zonal_mean_xy","zonal_mean_2d","polar","cosp_histogram","meridional_mean_2d","annual_cycle_zonal_mean","zonal_mean_2d_stratosphere","aerosol_aeronet"))
+sets = string_list(default=list("lat_lon","zonal_mean_xy","zonal_mean_2d","polar","cosp_histogram","meridional_mean_2d","annual_cycle_zonal_mean","zonal_mean_2d_stratosphere","aerosol_aeronet","aerosol_budget"))
 # Used for `test_name` and `short_test_name` in https://e3sm-project.github.io/e3sm_diags/_build/html/master/available-parameters.html
 short_name = string(default="")
 # See https://e3sm-project.github.io/e3sm_diags/_build/html/master/available-parameters.html


### PR DESCRIPTION
The new e3sm_diags release candidate has this new aerosol budget diagnostics set. And I added this to the default list in zppy. 