### PR TITLE
Add support for clm2 cam in e3sm_to_cmip call

### DIFF
--- a/zppy/templates/ts.bash
+++ b/zppy/templates/ts.bash
@@ -145,13 +145,13 @@ EOF
   srun -N 1 e3sm_to_cmip \
   --output-path \
   ${dest_cmip}/${tmp_dir} \
-  {% if input_files == 'elm.h0' -%}
+  {% if input_files.split(".")[0] == 'clm2' or input_files.split(".")[0] == 'elm' -%}
   --var-list \
   'mrsos, mrso, mrfso, mrros, mrro, prveg, evspsblveg, evspsblsoi, tran, tsl, lai, cLitter, cProduct, cSoilFast, cSoilMedium, cSoilSlow, fFire, fHarvest, cVeg, nbp, gpp, ra, rh' \
   --realm \
   lnd \
   {% endif -%}
-  {% if input_files == 'eam.h0' -%}
+  {% if input_files.split(".")[0] == 'cam' or input_files.split(".")[0] == 'eam' -%}
   --var-list \
   'pr, tas, rsds, rlds, rsus' \
   --realm \


### PR DESCRIPTION
There is an issue reported by @BunnyVon that e3sm_to_cmip call failed during time-series generation. The issue is that the input files has old components names `clm2` and `cam`. This PR updates the e3sm_to_cmip command to support these file names.