### PR TITLE
Support clm2 files

### DIFF
--- a/zppy/templates/ts.bash
+++ b/zppy/templates/ts.bash
@@ -105,7 +105,7 @@ cat input.txt | ncclimo \
 --tpd={{ tpd }} \
 {%- endif %}
 {%- if input_files.split(".")[0] == 'cam' or input_files.split(".")[0] == 'eam' or input_files.split(".")[0] == 'elm' or input_files.split(".")[0] == 'clm2'  %}
---prc_typ={{ input_files.split(".")[0] }}
+--prc_typ={{ input_files.split(".")[0][:3] }}
 {%- else %}
 --prc_typ=sgs
 {%- endif %}


### PR DESCRIPTION
Add a second fix to this PR is to support clm2 files in zppy's ncclimo call.
Issue reported by @BunnyVon 

```
ERROR: Invalid -P prc_typ option = clm2
HINT: Valid prc_typ arguments are 'airs', 'cam', 'clm', 'cice', 'ctsm', 'eam', 'eamxx', 'elm', 'hirdls', 'mali', 'mls', 'mod04', 'mpas', 'mpaso', 'mpasocean', 'mpascice', 'mpasseaice', 'mpassi', 'mwf', 'nil', 'rrg', and 'sgs'
```
Notes from Charlie:
This issue occurs with output from EAM v1 and ELM v1, which use cam and clm2 , respectively, in the output filenames. For EAM v1, use -P cam (it seems like you tried this and it works fine). For ELM v1, use -P clm and ncclimo should automagically use clm2 in the filenames. The take-home message is that -P == --prc_typ actually specifies a "processing type" which is usually though not always the same as the associated string used in history file names. For --prc_typ=clm the string is clm2. In all other respects, -P elm and -P clm behave identically.