### PR TITLE
Bump to v2.3.0rc1 without tbump

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "zppy" %}
-{% set version = "2.2.0" %}
+{% set version = "2.3.0rc1" %}
 
 package:
   name: {{ name|lower }}

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ data_files = package_files(
 
 setup(
     name="zppy",
-    version="2.2.0",
+    version="2.3.0rc1",
     author="Ryan Forsyth, Chris Golaz",
     author_email="forsyth2@llnl.gov, golaz1@llnl.gov",
     description="Post-processing software for E3SM",

--- a/tbump.toml
+++ b/tbump.toml
@@ -2,7 +2,7 @@
 github_url = "https://github.com/E3SM-Project/zppy.git"
 
 [version]
-current = "2.2.0"
+current = "2.3.0rc1"
 
 # Example of a semver regexp with support for PEP 440
 # release candidates.Make sure this matches current_version

--- a/zppy/__init__.py
+++ b/zppy/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "v2.2.0"
+__version__ = "v2.3.0rc1"


### PR DESCRIPTION
Bump to 2.3.0rc1.

Had to do this PR manually rather than using `tbump`. With `tbump`, I kept running into the following error:
```
[v2.3.0rc1 b66f311] Bump to 2.3.0rc1
 4 files changed, 4 insertions(+), 4 deletions(-)
To github.com:E3SM-Project/zppy.git
 ! [rejected]        main -> main (non-fast-forward)
error: failed to push some refs to 'github.com:E3SM-Project/zppy.git'
hint: Updates were rejected because a pushed branch tip is behind its remote
hint: counterpart. Check out this branch and integrate the remote changes
hint: (e.g. 'git pull ...') before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
Error: Command `git push upstream main` failed
```