### PR TITLE
Change workflows to mamba, take 2

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -118,10 +118,6 @@ jobs:
             ${{ runner.os }}-pip-
             ${{ runner.os }}-
 
-      # Using pip for Sphinx dependencies because it takes too long to reproduce a conda environment (~10 secs vs. 3-4 mins)
-      - name: Install Dependencies
-        run: |
-          mamba install -y sphinx==5.2.3 sphinx_rtd_theme==1.0.0 sphinx-multiversion==0.2.4 docutils==0.16
       - name: Build Sphinx Docs
         run: |
           cd docs

--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -64,7 +64,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: zppy_dev
-	  miniforge-variant: Mambaforge
+          miniforge-variant: Mambaforge
           miniforge-version: latest
           use-mamba: true
           mamba-version: "*"

--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -64,6 +64,10 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: zppy_dev
+	  miniforge-variant: Mambaforge
+          miniforge-version: latest
+          use-mamba: true
+          mamba-version: "*"
           environment-file: conda/dev.yml
           channel-priority: strict
           auto-update-conda: true
@@ -117,8 +121,7 @@ jobs:
       # Using pip for Sphinx dependencies because it takes too long to reproduce a conda environment (~10 secs vs. 3-4 mins)
       - name: Install Dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install sphinx==5.2.3 sphinx_rtd_theme==1.0.0 sphinx-multiversion==0.2.4 docutils==0.16
+          mamba install -y sphinx==5.2.3 sphinx_rtd_theme==1.0.0 sphinx-multiversion==0.2.4 docutils==0.16
       - name: Build Sphinx Docs
         run: |
           cd docs

--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -71,8 +71,6 @@ jobs:
           environment-file: conda/dev.yml
           channel-priority: strict
           auto-update-conda: true
-          # IMPORTANT: This needs to be set for caching to work properly!
-          use-only-tar-bz2: true
 
       - if: ${{ needs.check-jobs-to-skip.outputs.should_skip != 'true' }}
         name: Show Conda Environment Info
@@ -102,21 +100,36 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.9
-
-      - name: Cache pip
+      - name: Cache Conda
         uses: actions/cache@v3
+        env:
+          CACHE_NUMBER: 0
         with:
-          # This path is specific to Ubuntu
-          path: ~/.cache/pip
-          # Look to see if there is a cache hit for the corresponding requirements file
-          key: ${{ runner.os }}-pip-publish-docs
-          restore-keys: |
-            ${{ runner.os }}-pip-
-            ${{ runner.os }}-
+          path: ~/conda_pkgs_dir
+          key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{
+            hashFiles('conda/dev.yml') }}
+
+      - name: Build Conda Environment
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: zppy_dev
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          use-mamba: true
+          mamba-version: "*"
+          environment-file: conda/dev.yml
+          channel-priority: strict
+          auto-update-conda: true
+
+      - if: ${{ needs.check-jobs-to-skip.outputs.should_skip != 'true' }}
+        name: Show Conda Environment Info
+        run: |
+          conda config --set anaconda_upload no
+          conda info
+          conda list
+
+      - name: Install `zppy` Package
+        run: pip install .
 
       - name: Build Sphinx Docs
         run: |

--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -18,26 +18,36 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.9
-
-      - name: Cache pip
+      - name: Cache Conda
         uses: actions/cache@v3
+        env:
+          CACHE_NUMBER: 0
         with:
-          # This path is specific to Ubuntu
-          path: ~/.cache/pip
-          # Look to see if there is a cache hit for the corresponding requirements file
-          key: ${{ runner.os }}-pip-publish-docs
-          restore-keys: |
-            ${{ runner.os }}-pip-
-            ${{ runner.os }}-
+          path: ~/conda_pkgs_dir
+          key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{
+            hashFiles('conda/dev.yml') }}
 
-      # Using pip for Sphinx dependencies because it takes too long to reproduce a conda environment (~10 secs vs. 3-4 mins)
-      - name: Install Dependencies
+      - name: Build Conda Environment
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: zppy_dev
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          use-mamba: true
+          mamba-version: "*"
+          environment-file: conda/dev.yml
+          channel-priority: strict
+          auto-update-conda: true
+
+      - if: ${{ needs.check-jobs-to-skip.outputs.should_skip != 'true' }}
+        name: Show Conda Environment Info
         run: |
-          mamba install -y sphinx==5.2.3 sphinx_rtd_theme==1.0.0 sphinx-multiversion==0.2.4 docutils==0.16
+          conda config --set anaconda_upload no
+          conda info
+          conda list
+
+      - name: Install `zppy` Package
+        run: pip install .
 
       - name: Build Sphinx Docs
         run: |

--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -37,8 +37,7 @@ jobs:
       # Using pip for Sphinx dependencies because it takes too long to reproduce a conda environment (~10 secs vs. 3-4 mins)
       - name: Install Dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install sphinx==5.2.3 sphinx_rtd_theme==1.0.0 sphinx-multiversion==0.2.4 docutils==0.16
+          mamba install -y sphinx==5.2.3 sphinx_rtd_theme==1.0.0 sphinx-multiversion==0.2.4 docutils==0.16
 
       - name: Build Sphinx Docs
         run: |

--- a/conda/dev.yml
+++ b/conda/dev.yml
@@ -27,9 +27,8 @@ dependencies:
   # =================
   - sphinx=5.2.3
   - sphinx_rtd_theme=1.0.0
+  - sphinx-multiversion==0.2.4
   # Need to pin docutils because 0.17 has a bug with unordered lists
   # https://github.com/readthedocs/sphinx_rtd_theme/issues/1115
   - docutils=0.16
-  - pip:
-      - sphinx-multiversion==0.2.4
 prefix: /opt/miniconda3/envs/zppy_dev

--- a/conda/dev.yml
+++ b/conda/dev.yml
@@ -27,8 +27,9 @@ dependencies:
   # =================
   - sphinx=5.2.3
   - sphinx_rtd_theme=1.0.0
-  - sphinx-multiversion==0.2.4
   # Need to pin docutils because 0.17 has a bug with unordered lists
   # https://github.com/readthedocs/sphinx_rtd_theme/issues/1115
   - docutils=0.16
+  - pip:
+      - sphinx-multiversion==0.2.4
 prefix: /opt/miniconda3/envs/zppy_dev

--- a/conda/dev.yml
+++ b/conda/dev.yml
@@ -26,10 +26,9 @@ dependencies:
   # If versions are updated, also update in `.github/workflows/build_workflow.yml`
   # =================
   - sphinx=5.2.3
+  - sphinx-multiversion=0.2.4
   - sphinx_rtd_theme=1.0.0
   # Need to pin docutils because 0.17 has a bug with unordered lists
   # https://github.com/readthedocs/sphinx_rtd_theme/issues/1115
   - docutils=0.16
-  - pip:
-      - sphinx-multiversion==0.2.4
 prefix: /opt/miniconda3/envs/zppy_dev

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup(
     author_email="forsyth2@llnl.gov, golaz1@llnl.gov",
     description="Post-processing software for E3SM",
     python_requires=">=3.6",
-    intall_requires=["configobj>=5.0.0,<6.0.0", "jinja2>=2.0.0"],
     packages=find_packages(include=["zppy", "zppy.*"]),
     package_data={"": data_files},
     entry_points={"console_scripts": ["zppy=zppy.__main__:main"]},


### PR DESCRIPTION
This merge attempts to move all workflows (including building the documentation) to `mamba` instead of `pip`.