### PR TITLE
Bump to v2.3.0rc2 without tbump

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "zppy" %}
-{% set version = "2.3.0rc1" %}
+{% set version = "2.3.0rc2" %}
 
 package:
   name: {{ name|lower }}

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ data_files = package_files(
 
 setup(
     name="zppy",
-    version="2.3.0rc1",
+    version="2.3.0rc2",
     author="Ryan Forsyth, Chris Golaz",
     author_email="forsyth2@llnl.gov, golaz1@llnl.gov",
     description="Post-processing software for E3SM",

--- a/tbump.toml
+++ b/tbump.toml
@@ -2,7 +2,7 @@
 github_url = "https://github.com/E3SM-Project/zppy.git"
 
 [version]
-current = "2.3.0rc1"
+current = "2.3.0rc2"
 
 # Example of a semver regexp with support for PEP 440
 # release candidates.Make sure this matches current_version

--- a/zppy/__init__.py
+++ b/zppy/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "v2.3.0rc1"
+__version__ = "v2.3.0rc2"


### PR DESCRIPTION
Bump to v2.3.0rc2 without `tbump`.

Same error as in #437 prevents `tbump` usage.