### PR TITLE
Make parallel optional for climo

### DIFF
--- a/zppy/templates/climo.bash
+++ b/zppy/templates/climo.bash
@@ -34,7 +34,9 @@ ncclimo \
 {%- if vars != '' %}
 --vars={{ vars }} \
 {%- endif %}
+{%- if parallel != '' %}
 --parallel={{ parallel }} \
+{%- endif %}
 --yr_srt={{ yr_start }} \
 --yr_end={{ yr_end }} \
 --input={{ input }}/{{ input_subdir }} \
@@ -105,7 +107,9 @@ cat input.txt | ncclimo \
 {%- if vars != '' %}
 --vars={{ vars }} \
 {%- endif %}
+{%- if parallel != '' %}
 --parallel={{ parallel }} \
+{%- endif %}
 --yr_srt={{ yr_start }} \
 --yr_end={{ yr_end }} \
 {% if mapping_file == '' -%}


### PR DESCRIPTION
Make parallel optional for climo. Follow-up to #452.