### PR TITLE
add srun for running e3sm_diags

### DIFF
--- a/zppy/e3sm_diags.py
+++ b/zppy/e3sm_diags.py
@@ -222,7 +222,7 @@ def e3sm_diags(config, scriptDir, existing_bundles, job_ids_file):  # noqa: C901
                 p.pprint(c)
                 p.pprint(s)
 
-            export = "NONE"
+            export = "ALL"
             existing_bundles = handle_bundles(
                 c,
                 scriptFile,

--- a/zppy/templates/e3sm_diags.bash
+++ b/zppy/templates/e3sm_diags.bash
@@ -456,9 +456,9 @@ EOF
 cat > e3sm_diags.cfg << EOF
 {% include cfg %}
 EOF
-command="python -u e3sm.py -d e3sm_diags.cfg"
+command="srun -n 1 python -u e3sm.py -d e3sm_diags.cfg"
 {% else %}
-command="python -u e3sm.py"
+command="srun -n 1 python -u e3sm.py"
 {% endif %}
 
 # Run diagnostics


### PR DESCRIPTION
Fixes #485 for the PMI2_Init error and e3sm_diags slowness on Chrysalis.