### PR TITLE
Fix machine discovery on compute nodes

### DIFF
--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -5,7 +5,7 @@ Contributing to This Documentation
 .. highlight:: none
 
 Getting Started
-==========================
+===============
 
 This documentation is created using
 `Sphinx <http://www.sphinx-doc.org/en/stable>`_. Sphinx is an open-source tool
@@ -19,7 +19,7 @@ After merging a PR, GitHub Actions automates the documentation building process.
 It pushes the HTML build to the ``gh-pages`` branch, which is hosted on GitHub Pages.
 
 Edit Documentation
-===============================
+==================
 
 Sphinx uses `reStructuredText <http://docutils.sourceforge.net/rst.html>`_
 as its markup language. For more information on how to write documentation
@@ -30,9 +30,9 @@ using Sphinx, you can refer to
 
 1. Make sure that you have conda in your path. On NERSC machines, you can load it with: ::
 
-   $ module load python/3.7-anaconda-2019.10
+   $ module load python/3.9-anaconda-2021.11
 
-2. Clone the repository and checkout a branch from `main`: ::
+2. Clone the repository and checkout a branch from ``main``: ::
 
    $ cd <myDir>
    $ git clone https://github.com/<your-github-username>/zppy.git
@@ -64,7 +64,7 @@ using Sphinx, you can refer to
     $ git commit
     $ git push <fork-origin> <branch-name>
 
-8. <`OPTIONAL`> If you want to generate and view versioned docs: ::
+8. <``OPTIONAL``> If you want to generate and view versioned docs: ::
 
     $ # After commiting to your branch
     $ cd <myDir>/zppy/docs
@@ -92,7 +92,7 @@ Branches or tags that don’t contain both the sphinx ``source`` directory and t
     - Run ``sphinx-multiversion source _build/html --dump-metadata`` to see which tags/branches matched.
 
 Initial setup (obsolete/for reference only)
-============================================
+===========================================
 
 The instructions below only apply for the initial configuration of the
 Sphinx documentation on the Github repository. They are documented here
@@ -121,7 +121,7 @@ accept suggested default options, except ::
 
   Separate source and build directories (y/N) [n]: y
 
-Edit Makefile and change BUILDIR ::
+Edit Makefile and change ``BUILDIR`` ::
 
   BUILDDIR = docs
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -167,7 +167,7 @@ unified environment), you can update ``zppy`` by doing the following:  ::
 
 Unlike the latest stable release (i.e., the user environment), the development
 environment does not include ``zppy``.
-Instead, the developer will ``python -m pip install .`` to build ``zppy`` with changes
+Instead, the developer will ``python -m pip install -e .`` to build ``zppy`` with changes
 (see step 7 below).
 
 Furthermore, the dev environment includes quality assurance (QA) tools such as code formatters, linters, and ``pre-commit``.
@@ -249,15 +249,16 @@ Furthermore, the dev environment includes quality assurance (QA) tools such as c
 
         pre-commit install
 
-7. Make the desired changes to ``zppy``, then rebuild and install with:
+7. install ``zppy`` into the conda environment in edit mode (so code changes
+   are reflected in the environment as you make them) with:
 
     ::
 
-        pip install .
+        python -m pip install -e .
 
-8. Commit changes and make sure ``pre-commit`` checks pass
+8. Make the desired changes to ``zppy``.
 
-9. Commit changes
+9. Commit changes and make sure ``pre-commit`` checks pass:
 
     ::
 

--- a/zppy/__main__.py
+++ b/zppy/__main__.py
@@ -114,9 +114,13 @@ def main():  # noqa: C901
         pass
 
     if ("machine" not in config["default"]) or (config["default"]["machine"] == ""):
-        # MachineInfo below will then call `discover_machine()`,
-        # which only works on log-in nodes.
-        machine = None
+        if "E3SMU_MACHINE" in os.environ:
+            # Use the machine identified by E3SM-Unified
+            machine = os.environ["E3SMU_MACHINE"]
+        else:
+            # MachineInfo below will then call `discover_machine()`,
+            # which only works on log-in nodes.
+            machine = None
     else:
         # If `machine` is set, then MachineInfo can bypass the
         # `discover_machine()` function.


### PR DESCRIPTION
This merge uses an E3SM-Unified environment variable, `E3SMU_MACHINE`, to determine the machine if  this environment variable has been set (e.g. by sourcing an E3SM-Unified load script).  This makes it possible
to detect the machine on compute nodes if you are using E3SM-Unified.

This merge also cleans up a few issues with the docs that I noticed.

Partially addresses #406 