### PR TITLE
Reorder diags sets

### DIFF
--- a/zppy/templates/cryosphere.cfg
+++ b/zppy/templates/cryosphere.cfg
@@ -1,5 +1,5 @@
 [e3sm_diags]
-sets = "aerosol_aeronet","aerosol_budget","annual_cycle_zonal_mean","cosp_histogram","diurnal_cycle","enso_diags","lat_lon","meridional_mean_2d","polar","qbo","streamflow","zonal_mean_2d","zonal_mean_2d_stratosphere","zonal_mean_xy"
+sets= "lat_lon","zonal_mean_xy","zonal_mean_2d","polar","cosp_histogram","meridional_mean_2d","enso_diags","qbo","diurnal_cycle","annual_cycle_zonal_mean","streamflow","zonal_mean_2d_stratosphere","aerosol_aeronet","aerosol_budget"
 
 [mpas_analysis]
 generate = 'all', 'no_BGC', 'no_icebergs'

--- a/zppy/templates/default.ini
+++ b/zppy/templates/default.ini
@@ -188,7 +188,9 @@ run_type = string(default="model_vs_obs")
 # "qbo" requires `ref_final_yr` to be set.
 # "streamflow" requires `streamflow_obs_ts` to be set.
 # "tc_analysis" requires `tc_obs` to be set.
-sets = string_list(default=list("aerosol_aeronet","aerosol_budget","annual_cycle_zonal_mean","cosp_histogram","lat_lon","meridional_mean_2d","polar","zonal_mean_2d","zonal_mean_2d_stratosphere","zonal_mean_xy"))
+# The order of the `sets` list is the order the sets will show up in E3SM Diags.
+# `sets` below are ordered by 1) core or speciality and then 2) older to newer.
+sets = string_list(default=list("lat_lon","zonal_mean_xy","zonal_mean_2d","polar","cosp_histogram","meridional_mean_2d","annual_cycle_zonal_mean","zonal_mean_2d_stratosphere","aerosol_aeronet","aerosol_budget"))
 # Used for `test_name` and `short_test_name` in https://e3sm-project.github.io/e3sm_diags/_build/html/master/available-parameters.html
 short_name = string(default="")
 # See https://e3sm-project.github.io/e3sm_diags/_build/html/master/available-parameters.html

--- a/zppy/templates/water_cycle.cfg
+++ b/zppy/templates/water_cycle.cfg
@@ -1,5 +1,5 @@
 [e3sm_diags]
-sets = "aerosol_aeronet","aerosol_budget","annual_cycle_zonal_mean","cosp_histogram","diurnal_cycle","enso_diags","lat_lon","meridional_mean_2d","polar","qbo","streamflow","zonal_mean_2d","zonal_mean_2d_stratosphere","zonal_mean_xy"
+sets = "lat_lon","zonal_mean_xy","zonal_mean_2d","polar","cosp_histogram","meridional_mean_2d","enso_diags","qbo","diurnal_cycle","annual_cycle_zonal_mean","streamflow","zonal_mean_2d_stratosphere","aerosol_aeronet","aerosol_budget"
 
 [mpas_analysis]
 generate = 'all', 'no_landIceCavities', 'no_BGC', 'no_icebergs', 'no_min', 'no_max', 'no_sose', 'no_climatologyMapAntarcticMelt', 'no_regionalTSDiagrams', 'no_timeSeriesAntarcticMelt', 'no_timeSeriesOceanRegions', 'no_climatologyMapSose', 'no_woceTransects', 'no_soseTransects', 'no_geojsonTransects', 'no_oceanRegionalProfiles', 'no_hovmollerOceanRegions'


### PR DESCRIPTION
Reorder diags sets by 1) core or speciality and then 2) older to newer, rather than the alphabetical order introduced in #458. The alphabetical order introduced an error to E3SM Diags: https://github.com/E3SM-Project/e3sm_diags/issues/738.

Benefits of alphabetical order (introduced in #458):
-  Improved readability/usability. Much easier to see if you're including all the sets you wanted to. Much easier for people viewing the diagnostics to locate the set they want to view.
- Makes it clear where a set should be inserted. (e.g., `diurnal_cycle` isn't included in `sets` by default, so at which point in the list should it be added if you want it?)

Benefits of custom order (before #458, again after this pull request):
- Some sets (notably `lat_lon`) _must_ be run earlier.
- We want the sets most people use (the core set) to be listed first.
- People are used to the current order.