### PR TITLE
Remove waves and eke from MPAS-Analysis generate option

### DIFF
--- a/zppy/templates/cryosphere.cfg
+++ b/zppy/templates/cryosphere.cfg
@@ -2,4 +2,4 @@
 sets= "lat_lon","zonal_mean_xy","zonal_mean_2d","polar","cosp_histogram","meridional_mean_2d","enso_diags","qbo","diurnal_cycle","annual_cycle_zonal_mean","streamflow","zonal_mean_2d_stratosphere","aerosol_aeronet","aerosol_budget"
 
 [mpas_analysis]
-generate = 'all', 'no_BGC', 'no_icebergs'
+generate = 'all', 'no_BGC', 'no_icebergs', 'no_waves', 'no_eke'

--- a/zppy/templates/default.ini
+++ b/zppy/templates/default.ini
@@ -257,7 +257,7 @@ anomalyRefYear = integer(default=1)
 cache = boolean(default=True)
 # Note that environment_commands needs to be the same for all related runs of [mpas_analysis].
 # For example, if years 1-50 are run using one environment and years 51-100 are run using another, MPAS-Analysis may fail.
-generate = string_list(default=list('all', 'no_landIceCavities', 'no_BGC', 'no_icebergs', 'no_min', 'no_max', 'no_sose', 'no_climatologyMapAntarcticMelt', 'no_regionalTSDiagrams', 'no_timeSeriesAntarcticMelt', 'no_timeSeriesOceanRegions', 'no_climatologyMapSose', 'no_woceTransects', 'no_soseTransects', 'no_geojsonTransects', 'no_oceanRegionalProfiles', 'no_hovmollerOceanRegions'))
+generate = string_list(default=list('all', 'no_landIceCavities', 'no_BGC', 'no_icebergs', 'no_min', 'no_max', 'no_sose', 'no_waves', 'no_eke', 'no_climatologyMapAntarcticMelt', 'no_regionalTSDiagrams', 'no_timeSeriesAntarcticMelt', 'no_timeSeriesOceanRegions', 'no_climatologyMapSose', 'no_woceTransects', 'no_soseTransects', 'no_geojsonTransects', 'no_oceanRegionalProfiles', 'no_hovmollerOceanRegions'))
 mapMpiTasks = integer(default=6)
 mpaso_nml = string(default="mpaso_in")
 mpassi_nml = string(default="mpassi_in")

--- a/zppy/templates/water_cycle.cfg
+++ b/zppy/templates/water_cycle.cfg
@@ -2,4 +2,4 @@
 sets = "lat_lon","zonal_mean_xy","zonal_mean_2d","polar","cosp_histogram","meridional_mean_2d","enso_diags","qbo","diurnal_cycle","annual_cycle_zonal_mean","streamflow","zonal_mean_2d_stratosphere","aerosol_aeronet","aerosol_budget"
 
 [mpas_analysis]
-generate = 'all', 'no_landIceCavities', 'no_BGC', 'no_icebergs', 'no_min', 'no_max', 'no_sose', 'no_climatologyMapAntarcticMelt', 'no_regionalTSDiagrams', 'no_timeSeriesAntarcticMelt', 'no_timeSeriesOceanRegions', 'no_climatologyMapSose', 'no_woceTransects', 'no_soseTransects', 'no_geojsonTransects', 'no_oceanRegionalProfiles', 'no_hovmollerOceanRegions'
+generate = 'all', 'no_landIceCavities', 'no_BGC', 'no_icebergs', 'no_min', 'no_max', 'no_sose', 'no_waves', 'no_eke', 'no_climatologyMapAntarcticMelt', 'no_regionalTSDiagrams', 'no_timeSeriesAntarcticMelt', 'no_timeSeriesOceanRegions', 'no_climatologyMapSose', 'no_woceTransects', 'no_soseTransects', 'no_geojsonTransects', 'no_oceanRegionalProfiles', 'no_hovmollerOceanRegions'


### PR DESCRIPTION
Typical E3SMv3 WCYCL and CRYO configurations will not have the output necessary to run waves and eddy kinetic energy (EKE) analysis.  It should be turned off to prevent confusing (though not fatal) errors in the setup stage of an MPAS-Analysis run.