### PR TITLE
[WIP] Add mixed-phase partition plot

### DIFF
--- a/zppy/e3sm_diags.py
+++ b/zppy/e3sm_diags.py
@@ -201,6 +201,7 @@ def e3sm_diags(config, scriptDir, existing_bundles, job_ids_file):  # noqa: C901
                         ("enso_diags" in c["sets"])
                         or ("qbo" in c["sets"])
                         or ("area_mean_time_series" in c["sets"])
+                        or ("mp_partition" in c["sets"])
                     ):
                         dependencies.append(
                             os.path.join(

--- a/zppy/templates/e3sm_diags.bash
+++ b/zppy/templates/e3sm_diags.bash
@@ -190,7 +190,7 @@ create_links_climo_diurnal ${climo_diurnal_dir_source} ${climo_diurnal_dir_ref} 
 {%- endif %}
 {%- endif %}
 
-{%- if ("enso_diags" in sets) or ("qbo" in sets) or ("area_mean_time_series" in sets) %}
+{%- if ("enso_diags" in sets) or ("qbo" in sets) or ("mp_partition" in sets) or ("area_mean_time_series" in sets) %}
 {% if run_type == "model_vs_obs" %}
 ts_dir_primary=ts
 {% elif run_type == "model_vs_model" %}
@@ -205,6 +205,7 @@ ts_dir_ref=ts_ref
 create_links_ts ${ts_dir_source} ${ts_dir_ref} ${ref_Y1} ${ref_Y2} 6
 {%- endif %}
 {%- endif %}
+
 
 {%- if "streamflow" in sets %}
 {% if run_type == "model_vs_obs" %}
@@ -261,6 +262,9 @@ from e3sm_diags.parameter.tc_analysis_parameter import TCAnalysisParameter
 {%- endif %}
 {%- if "lat_lon_land" in sets %}
 from e3sm_diags.parameter.lat_lon_land_parameter import LatLonLandParameter
+{%- endif %}
+{%- if "mp_partition" in sets %}
+from e3sm_diags.parameter.mp_partition_parameter import MPpartitionParameter
 {%- endif %}
 
 
@@ -415,6 +419,26 @@ if {{ swap_test_ref }}:
    ts_param.short_test_name, ts_param.short_ref_name = ts_param.short_ref_name, ts_param.short_test_name
 {%- endif %}
 params.append(ts_param)
+{%- endif %}
+
+{%- if "mp_partition" in sets %}
+mp_param = MPpartitionParameter()
+mp_param.test_data_path = '${ts_dir_source}'
+mp_param.test_name = short_name
+mp_param.test_start_yr = start_yr
+mp_param.test_end_yr = end_yr
+{% if run_type == "model_vs_model" %}
+# Reference
+mp_param.reference_data_path = '${ts_dir_ref}'
+mp_param.ref_name = '${ref_name}'
+mp_param.short_ref_name = '{{ short_ref_name }}'
+# Optionally, swap test and reference model
+if {{ swap_test_ref }}:
+   mp_param.test_data_path, mp_param.reference_data_path = mp_param.reference_data_path, mp_param.test_data_path
+   mp_param.test_name, mp_param.ref_name = mp_param.ref_name, mp_param.test_name
+   mp_param.short_test_name, mp_param.short_ref_name = mp_param.short_ref_name, mp_param.short_test_name
+{%- endif %}
+params.append(mp_param)
 {%- endif %}
 
 {%- if "diurnal_cycle" in sets %}

--- a/zppy/templates/ts.bash
+++ b/zppy/templates/ts.bash
@@ -65,6 +65,11 @@ vars={{ vars }}
 # https://stackoverflow.com/questions/26457052/remove-a-substring-from-a-bash-variable
 # Remove U, since it is a 3D variable and thus will not work with rgn_avg
 vars=${vars//,U}
+# Remove more 3D variables:
+vars=${vars//,T}
+vars=${vars//,CLDICE}
+vars=${vars//,CLDLIQ}
+
 {%- else %}
 vars={{ vars }}
 {%- endif %}


### PR DESCRIPTION
Adding mixed-phase partition plot form E3SM Diags. 

@golaz @wlin7 @shaochengx Just a heads-up that this is an example plot of the mixed phase partition plot with the first historical ensemble: 
https://web.lcrc.anl.gov/public/e3sm/diagnostic_output/ac.zhang40/E3SMv3_mp/v3.LR.historical_0051/e3sm_diags/atm_monthly_180x360_aave/model_vs_obs_1985-2014/viewer/mp_partition/variable/lcf/plot.html
The deviation of v3 from v2 is obvious. It is expected because the cloud ice (CLDICE) used in this diagnostics has a changed definition that both ice and snow are in this same category, thus results lower liquid condensation fraction. 

@zyuying and I planned to use CLD_CAL_TMPLIQ/ICE from simulator to replace CLDICE to make more meaningful comparison. It needs additional development in E3SM Diags, therefore, we won't have this set ready for next zppy release.

Also tagging @susburrows because this feature in e3sm diags was also requested by Aerosol Working Group. 
