### PR TITLE
Fix clm2 support

### DIFF
--- a/zppy/utils.py
+++ b/zppy/utils.py
@@ -156,7 +156,10 @@ def getComponent(input_component, input_files):
         prc_typ = tmp
     elif tmp in ("cpl",):
         component = "cpl"
-    elif tmp in ("clm2", "elm"):
+    elif tmp in ("clm2",):
+        component = "lnd"
+        prc_typ = "clm"
+    elif tmp in ("elm",):
         component = "lnd"
         prc_typ = tmp
     elif tmp in ("mosart",):


### PR DESCRIPTION
Fix clm2 support. Follow-up fix to #421, addressing an accidental reversion in #424. (See https://github.com/E3SM-Project/zppy/pull/421#issuecomment-2168953021 for details)