### PR TITLE
Add minimal case cfgs

### DIFF
--- a/tests/integration/generated/directions_chrysalis.md
+++ b/tests/integration/generated/directions_chrysalis.md
@@ -145,3 +145,12 @@ cp -r /lcrc/group/e3sm/ac.forsyth2/zppy_test_bundles_output/<UNIQUE ID>/v2.LR.hi
 ```
 cp -r /lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_test_complete_run_www/<UNIQUE ID>/v2.LR.historical_0201 /lcrc/group/e3sm/public_html/zppy_test_resources/expected_complete_run_unified_<#>
 ```
+
+## Minimal Cases
+
+Some tests specifically check minimal zppy cfgs:
+i.e., cfgs with as few parameters as possible to test a specific case.
+If your code changes could interact with these minimal cases,
+then you should run the relevant ones to make sure they still work.
+
+Read and run `tests/integration/run_min_cases.sh`.

--- a/tests/integration/generated/test_min_case_diags_mvm_climo_diurnal_1_chrysalis.cfg
+++ b/tests/integration/generated/test_min_case_diags_mvm_climo_diurnal_1_chrysalis.cfg
@@ -1,0 +1,33 @@
+[default]
+case = v2.LR.historical_0201
+constraint = ""
+dry_run = "False"
+environment_commands = ""
+input = "/lcrc/group/e3sm/ac.forsyth2//E3SMv2/v2.LR.historical_0201"
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "/lcrc/group/e3sm/ac.forsyth2/zppy_test_min_case_diags_mvm_climo_diurnal_1_output/unique_id/v2.LR.historical_0201"
+partition = "debug"
+qos = "regular"
+www = "/lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_test_min_case_diags_mvm_climo_diurnal_1_www/unique_id"
+
+[climo]
+active = True
+walltime = "00:30:00"
+years = "1850:1854:4"
+
+  [[ atm_monthly_diurnal_8xdaily_180x360_aave ]]
+  # On Chrysalis, this produces output in:
+  # /lcrc/group/e3sm/ac.forsyth2/zppy_test_min_case_diags_mvm_climo_diurnal_1_output/<unique_id>/v2.LR.historical_0201/post/atm/180x360_aave/clim_diurnal_8xdaily/4yr
+  # Notice the output is placed in `post/atm/{grid}/clim_{frequency}/<year-increment from {years}>yr`
+  # ls:
+  # v2.LR.historical_0201.eam.h4_01_185001_185301_climo.nc  v2.LR.historical_0201.eam.h4_07_185007_185307_climo.nc  v2.LR.historical_0201.eam.h4_ANN_185001_185312_climo.nc
+  # v2.LR.historical_0201.eam.h4_02_185002_185302_climo.nc  v2.LR.historical_0201.eam.h4_08_185008_185308_climo.nc  v2.LR.historical_0201.eam.h4_DJF_185001_185312_climo.nc
+  # v2.LR.historical_0201.eam.h4_03_185003_185303_climo.nc  v2.LR.historical_0201.eam.h4_09_185009_185309_climo.nc  v2.LR.historical_0201.eam.h4_JJA_185006_185308_climo.nc
+  # v2.LR.historical_0201.eam.h4_04_185004_185304_climo.nc  v2.LR.historical_0201.eam.h4_10_185010_185310_climo.nc  v2.LR.historical_0201.eam.h4_MAM_185003_185305_climo.nc
+  # v2.LR.historical_0201.eam.h4_05_185005_185305_climo.nc  v2.LR.historical_0201.eam.h4_11_185011_185311_climo.nc  v2.LR.historical_0201.eam.h4_SON_185009_185311_climo.nc
+  # v2.LR.historical_0201.eam.h4_06_185006_185306_climo.nc  v2.LR.historical_0201.eam.h4_12_185012_185312_climo.nc
+  frequency = "diurnal_8xdaily"
+  input_files = "eam.h4"
+  input_subdir = "archive/atm/hist"
+  vars = "PRECT"

--- a/tests/integration/generated/test_min_case_diags_mvm_climo_diurnal_2_chrysalis.cfg
+++ b/tests/integration/generated/test_min_case_diags_mvm_climo_diurnal_2_chrysalis.cfg
@@ -1,0 +1,56 @@
+[default]
+case = v2.LR.historical_0201
+constraint = ""
+dry_run = "False"
+environment_commands = ""
+input = "/lcrc/group/e3sm/ac.forsyth2//E3SMv2/v2.LR.historical_0201"
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "/lcrc/group/e3sm/ac.forsyth2/zppy_test_min_case_diags_mvm_climo_diurnal_2_output/unique_id/v2.LR.historical_0201"
+partition = "debug"
+qos = "regular"
+www = "/lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_test_min_case_diags_mvm_climo_diurnal_2_www/unique_id"
+
+[climo]
+active = True
+walltime = "00:30:00"
+years = "1860:1864:4",
+
+  [[ atm_monthly_diurnal_8xdaily_180x360_aave ]]
+  # On Chrysalis, this produces output in:
+  # /lcrc/group/e3sm/ac.forsyth2/zppy_test_min_case_diags_mvm_climo_diurnal_2_output/<unique_id>/v2.LR.historical_0201/post/atm/180x360_aave/clim_diurnal_8xdaily/4yr
+  # Notice the output is placed in `post/atm/{grid}/clim_{frequency}/<year-increment from {years}>yr`
+  # ls:
+  # v2.LR.historical_0201.eam.h4_01_186001_186301_climo.nc  v2.LR.historical_0201.eam.h4_07_186007_186307_climo.nc  v2.LR.historical_0201.eam.h4_ANN_186001_186312_climo.nc
+  # v2.LR.historical_0201.eam.h4_02_186002_186302_climo.nc  v2.LR.historical_0201.eam.h4_08_186008_186308_climo.nc  v2.LR.historical_0201.eam.h4_DJF_186001_186312_climo.nc
+  # v2.LR.historical_0201.eam.h4_03_186003_186303_climo.nc  v2.LR.historical_0201.eam.h4_09_186009_186309_climo.nc  v2.LR.historical_0201.eam.h4_JJA_186006_186308_climo.nc
+  # v2.LR.historical_0201.eam.h4_04_186004_186304_climo.nc  v2.LR.historical_0201.eam.h4_10_186010_186310_climo.nc  v2.LR.historical_0201.eam.h4_MAM_186003_186305_climo.nc
+  # v2.LR.historical_0201.eam.h4_05_186005_186305_climo.nc  v2.LR.historical_0201.eam.h4_11_186011_186311_climo.nc  v2.LR.historical_0201.eam.h4_SON_186009_186311_climo.nc
+  # v2.LR.historical_0201.eam.h4_06_186006_186306_climo.nc  v2.LR.historical_0201.eam.h4_12_186012_186312_climo.nc
+  frequency = "diurnal_8xdaily"
+  input_files = "eam.h4"
+  input_subdir = "archive/atm/hist"
+  vars = "PRECT"
+
+[e3sm_diags]
+active = True
+grid = '180x360_aave'
+sets = "diurnal_cycle",
+short_name = 'v2.LR.historical_0201'
+
+  [[ atm_monthly_180x360_aave_mvm ]]
+  climo_diurnal_frequency = "diurnal_8xdaily"
+  climo_diurnal_subsection = "atm_monthly_diurnal_8xdaily_180x360_aave"
+  diff_title = "Difference"
+  partition = "compute"
+  qos = "regular"
+  ref_name = "v2.LR.historical_0201"
+  ref_years = "1850-1853",
+  # Use `_1` as reference
+  reference_data_path_climo_diurnal = "/lcrc/group/e3sm/ac.forsyth2/zppy_test_min_case_diags_mvm_climo_diurnal_1_output/unique_id/v2.LR.historical_0201/post/atm/180x360_aave/clim_diurnal_8xdaily"
+  run_type = "model_vs_model"
+  short_ref_name = "v2.LR.historical_0201"
+  swap_test_ref = False
+  tag = "model_vs_model"
+  walltime = "5:00:00"
+  years = "1860:1864:4",

--- a/tests/integration/generated/test_min_case_e3sm_diags_depend_on_climo_chrysalis.cfg
+++ b/tests/integration/generated/test_min_case_e3sm_diags_depend_on_climo_chrysalis.cfg
@@ -1,0 +1,37 @@
+[default]
+case = "v3.LR.historical_0051"
+constraint = ""
+dry_run = "False"
+environment_commands = ""
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/v3.LR.historical_0051
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "/lcrc/group/e3sm/ac.forsyth2/zppy_min_case_e3sm_diags_depend_on_climo_output/unique_id/v2.LR.historical_0201"
+partition = "debug"
+qos = "regular"
+www = "/lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_min_case_e3sm_diags_depend_on_climo_www/unique_id"
+years = "1985:1989:4",
+
+[climo]
+active = True
+walltime = "00:30:00"
+
+  [[ atm_monthly_180x360_aave ]]
+  frequency = "monthly"
+  input_files = "eam.h0"
+  input_subdir = "archive/atm/hist"
+  vars = ""
+
+[e3sm_diags]
+active = True
+grid = '180x360_aave'
+multiprocessing = True
+num_workers = 8
+partition = "compute"
+qos = "regular"
+short_name = "v3.LR.historical_0051"
+walltime = "5:00:00"
+
+  [[ atm_monthly_180x360_aave ]]
+  climo_subsection = "atm_monthly_180x360_aave"
+  sets = "lat_lon","zonal_mean_xy","zonal_mean_2d","polar","cosp_histogram","meridional_mean_2d","annual_cycle_zonal_mean","zonal_mean_2d_stratosphere",

--- a/tests/integration/generated/test_min_case_e3sm_diags_depend_on_climo_mvm_1_chrysalis.cfg
+++ b/tests/integration/generated/test_min_case_e3sm_diags_depend_on_climo_mvm_1_chrysalis.cfg
@@ -1,0 +1,23 @@
+[default]
+case = "v3.LR.historical_0051"
+constraint = ""
+dry_run = "False"
+environment_commands = ""
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/v3.LR.historical_0051
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "/lcrc/group/e3sm/ac.forsyth2/zppy_min_case_e3sm_diags_depend_on_climo_mvm_1_output/unique_id/v2.LR.historical_0201"
+partition = "debug"
+qos = "regular"
+www = "/lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_min_case_e3sm_diags_depend_on_climo_mvm_1_www/unique_id"
+years = "1985:1989:4",
+
+[climo]
+active = True
+walltime = "00:30:00"
+
+  [[ atm_monthly_180x360_aave ]]
+  frequency = "monthly"
+  input_files = "eam.h0"
+  input_subdir = "archive/atm/hist"
+  vars = ""

--- a/tests/integration/generated/test_min_case_e3sm_diags_depend_on_climo_mvm_2_chrysalis.cfg
+++ b/tests/integration/generated/test_min_case_e3sm_diags_depend_on_climo_mvm_2_chrysalis.cfg
@@ -1,0 +1,52 @@
+[default]
+case = "v3.LR.historical_0051"
+constraint = ""
+dry_run = "False"
+environment_commands = ""
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/v3.LR.historical_0051
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "/lcrc/group/e3sm/ac.forsyth2/zppy_min_case_e3sm_diags_depend_on_climo_mvm_2_output/unique_id/v2.LR.historical_0201"
+partition = "debug"
+qos = "regular"
+www = "/lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_min_case_e3sm_diags_depend_on_climo_mvm_2_www/unique_id"
+years = "1995:1999:4",
+
+[climo]
+active = True
+walltime = "00:30:00"
+
+  [[ atm_monthly_180x360_aave ]]
+  frequency = "monthly"
+  input_files = "eam.h0"
+  input_subdir = "archive/atm/hist"
+  vars = ""
+
+[e3sm_diags]
+active = True
+grid = '180x360_aave'
+multiprocessing = True
+num_workers = 8
+partition = "compute"
+qos = "regular"
+short_name = "v3.LR.historical_0051"
+walltime = "5:00:00"
+
+  [[ atm_monthly_180x360_aave_mvm ]]
+  # Test model-vs-model using the same files as the reference
+  climo_subsection = "atm_monthly_180x360_aave"
+  diff_title = "Difference"
+  ref_final_yr = 1988
+  ref_name = "v3.LR.historical_0051"
+  ref_start_yr = 1985
+  ref_years = "1985-1988",
+  # Use _1 as reference
+  reference_data_path = "/lcrc/group/e3sm/ac.forsyth2/zppy_min_case_e3sm_diags_depend_on_climo_mvm_1_output/unique_id/v3.LR.historical_0051/post/atm/180x360_aave/clim"
+  run_type = "model_vs_model"
+  sets = "lat_lon","zonal_mean_xy","zonal_mean_2d","polar","cosp_histogram","meridional_mean_2d","annual_cycle_zonal_mean","zonal_mean_2d_stratosphere",
+  short_ref_name = "v3.LR.historical_0051"
+  swap_test_ref = False
+  tag = "model_vs_model"
+  ts_num_years_ref = 4
+  ts_subsection = "atm_monthly_180x360_aave"
+  years = "1995-1998",

--- a/tests/integration/generated/test_min_case_e3sm_diags_depend_on_ts_chrysalis.cfg
+++ b/tests/integration/generated/test_min_case_e3sm_diags_depend_on_ts_chrysalis.cfg
@@ -1,0 +1,38 @@
+[default]
+case = "v3.LR.historical_0051"
+constraint = ""
+dry_run = "False"
+environment_commands = ""
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/v3.LR.historical_0051
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "/lcrc/group/e3sm/ac.forsyth2/zppy_min_case_e3sm_diags_depend_on_ts_output/unique_id/v2.LR.historical_0201"
+partition = "debug"
+qos = "regular"
+www = "/lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_min_case_e3sm_diags_depend_on_ts_www/unique_id"
+years = "1985:1989:4",
+
+[ts]
+active = True
+e3sm_to_cmip_environment_commands = ""
+walltime = "00:30:00"
+
+  [[ atm_monthly_180x360_aave ]]
+  frequency = "monthly"
+  input_files = "eam.h0"
+  input_subdir = "archive/atm/hist"
+  #ts_fmt = "cmip"
+
+[e3sm_diags]
+active = True
+grid = '180x360_aave'
+multiprocessing = True
+num_workers = 8
+partition = "compute"
+qos = "regular"
+short_name = "v3.LR.historical_0051"
+ts_num_years = 4
+walltime = "5:00:00"
+
+  [[ atm_monthly_180x360_aave ]]
+  sets = "enso_diags","qbo",

--- a/tests/integration/generated/test_min_case_e3sm_diags_depend_on_ts_mvm_1_chrysalis.cfg
+++ b/tests/integration/generated/test_min_case_e3sm_diags_depend_on_ts_mvm_1_chrysalis.cfg
@@ -1,0 +1,24 @@
+[default]
+case = "v3.LR.historical_0051"
+constraint = ""
+dry_run = "False"
+environment_commands = ""
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/v3.LR.historical_0051
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "/lcrc/group/e3sm/ac.forsyth2/zppy_min_case_e3sm_diags_depend_on_ts_mvm_1_output/unique_id/v2.LR.historical_0201"
+partition = "debug"
+qos = "regular"
+www = "/lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_min_case_e3sm_diags_depend_on_ts_mvm_1_www/unique_id"
+years = "1985:1989:4",
+
+[ts]
+active = True
+e3sm_to_cmip_environment_commands = ""
+walltime = "00:30:00"
+
+  [[ atm_monthly_180x360_aave ]]
+  frequency = "monthly"
+  input_files = "eam.h0"
+  input_subdir = "archive/atm/hist"
+  #ts_fmt = "cmip"

--- a/tests/integration/generated/test_min_case_e3sm_diags_depend_on_ts_mvm_2_chrysalis.cfg
+++ b/tests/integration/generated/test_min_case_e3sm_diags_depend_on_ts_mvm_2_chrysalis.cfg
@@ -1,0 +1,55 @@
+[default]
+case = "v3.LR.historical_0051"
+constraint = ""
+dry_run = "False"
+environment_commands = ""
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/v3.LR.historical_0051
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "/lcrc/group/e3sm/ac.forsyth2/zppy_min_case_e3sm_diags_depend_on_ts_mvm_2_output/unique_id/v2.LR.historical_0201"
+partition = "debug"
+qos = "regular"
+www = "/lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_min_case_e3sm_diags_depend_on_ts_mvm_2_www/unique_id"
+years = "1995:1999:4",
+
+[ts]
+active = True
+e3sm_to_cmip_environment_commands = ""
+walltime = "00:30:00"
+
+  [[ atm_monthly_180x360_aave ]]
+  frequency = "monthly"
+  input_files = "eam.h0"
+  input_subdir = "archive/atm/hist"
+  #ts_fmt = "cmip"
+
+[e3sm_diags]
+active = True
+grid = '180x360_aave'
+multiprocessing = True
+num_workers = 8
+partition = "compute"
+qos = "regular"
+short_name = "v3.LR.historical_0051"
+ts_num_years = 4
+walltime = "5:00:00"
+
+  [[ atm_monthly_180x360_aave_mvm ]]
+  # Test model-vs-model using the same files as the reference
+  climo_subsection = "atm_monthly_180x360_aave"
+  diff_title = "Difference"
+  ref_final_yr = 1988
+  ref_name = "v3.LR.historical_0051"
+  ref_start_yr = 1985
+  ref_years = "1985-1988",
+  # Use _1 as reference
+  reference_data_path = "/lcrc/group/e3sm/ac.forsyth2/zppy_min_case_e3sm_diags_depend_on_ts_mvm_1_output/unique_id/v3.LR.historical_0051/post/atm/180x360_aave/clim"
+  run_type = "model_vs_model"
+  sets = "enso_diags","qbo",
+  short_ref_name = "v3.LR.historical_0051"
+  swap_test_ref = False
+  tag = "model_vs_model"
+  ts_num_years_ref = 4
+  ts_subsection = "atm_monthly_180x360_aave"
+  walltime = "5:00:00"
+  years = "1995-1998",

--- a/tests/integration/generated/test_min_case_e3sm_diags_diurnal_cycle_chrysalis.cfg
+++ b/tests/integration/generated/test_min_case_e3sm_diags_diurnal_cycle_chrysalis.cfg
@@ -1,0 +1,40 @@
+[default]
+case = "v3.LR.historical_0051"
+constraint = ""
+dry_run = "False"
+environment_commands = ""
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/v3.LR.historical_0051
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "/lcrc/group/e3sm/ac.forsyth2/zppy_min_case_e3sm_diags_diurnal_cycle_output/unique_id/v2.LR.historical_0201"
+partition = "debug"
+qos = "regular"
+www = "/lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_min_case_e3sm_diags_diurnal_cycle_www/unique_id"
+years = "1985:1989:4",
+
+[climo]
+active = True
+walltime = "00:30:00"
+
+  [[ atm_monthly_diurnal_8xdaily_180x360_aave ]]
+  frequency = "diurnal_8xdaily"
+  input_files = "eam.h3"
+  input_subdir = "archive/atm/hist"
+  vars = "PRECT"
+
+[e3sm_diags]
+active = True
+grid = '180x360_aave'
+multiprocessing = True
+num_workers = 8
+partition = "compute"
+qos = "regular"
+short_name = "v3.LR.historical_0051"
+ts_num_years = 4
+walltime = "5:00:00"
+
+  [[ atm_monthly_180x360_aave ]]
+  climo_diurnal_frequency = "diurnal_8xdaily"
+  climo_diurnal_subsection = "atm_monthly_diurnal_8xdaily_180x360_aave"
+  dc_obs_climo = '/lcrc/group/e3sm/public_html/e3sm_diags_test_data/unit_test_complete_run/obs/climatology'
+  sets = "diurnal_cycle",

--- a/tests/integration/generated/test_min_case_e3sm_diags_diurnal_cycle_mvm_1_chrysalis.cfg
+++ b/tests/integration/generated/test_min_case_e3sm_diags_diurnal_cycle_mvm_1_chrysalis.cfg
@@ -1,0 +1,23 @@
+[default]
+case = "v3.LR.historical_0051"
+constraint = ""
+dry_run = "False"
+environment_commands = ""
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/v3.LR.historical_0051
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "/lcrc/group/e3sm/ac.forsyth2/zppy_min_case_e3sm_diags_diurnal_cycle_mvm_1_output/unique_id/v2.LR.historical_0201"
+partition = "debug"
+qos = "regular"
+www = "/lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_min_case_e3sm_diags_diurnal_cycle_mvm_1_www/unique_id"
+years = "1985:1989:4",
+
+[climo]
+active = True
+walltime = "00:30:00"
+
+  [[ atm_monthly_diurnal_8xdaily_180x360_aave ]]
+  frequency = "diurnal_8xdaily"
+  input_files = "eam.h3"
+  input_subdir = "archive/atm/hist"
+  vars = "PRECT"

--- a/tests/integration/generated/test_min_case_e3sm_diags_diurnal_cycle_mvm_2_chrysalis.cfg
+++ b/tests/integration/generated/test_min_case_e3sm_diags_diurnal_cycle_mvm_2_chrysalis.cfg
@@ -1,0 +1,47 @@
+[default]
+case = "v3.LR.historical_0051"
+constraint = ""
+dry_run = "False"
+environment_commands = ""
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/v3.LR.historical_0051
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "/lcrc/group/e3sm/ac.forsyth2/zppy_min_case_e3sm_diags_diurnal_cycle_mvm_2_output/unique_id/v2.LR.historical_0201"
+partition = "debug"
+qos = "regular"
+www = "/lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_min_case_e3sm_diags_diurnal_cycle_mvm_2_www/unique_id"
+years = "1995:1999:4",
+
+[climo]
+active = True
+walltime = "00:30:00"
+
+  [[ atm_monthly_diurnal_8xdaily_180x360_aave ]]
+  frequency = "diurnal_8xdaily"
+  input_files = "eam.h3"
+  input_subdir = "archive/atm/hist"
+  vars = "PRECT"
+
+[e3sm_diags]
+active = True
+grid = '180x360_aave'
+multiprocessing = True
+num_workers = 8
+partition = "compute"
+qos = "regular"
+short_name = "v3.LR.historical_0051"
+walltime = "5:00:00"
+
+  [[ atm_monthly_180x360_aave_mvm ]]
+  climo_diurnal_frequency = "diurnal_8xdaily"
+  climo_diurnal_subsection = "atm_monthly_diurnal_8xdaily_180x360_aave"
+  diff_title = "Difference"
+  ref_name = "v3.LR.historical_0051"
+  ref_years = "1985-1988",
+  # Use _1 as reference
+  reference_data_path_climo_diurnal = "/lcrc/group/e3sm/ac.forsyth2/zppy_min_case_e3sm_diags_diurnal_cycle_mvm_1_output/unique_id/v3.LR.historical_0051/post/atm/180x360_aave/clim_diurnal_8xdaily"
+  run_type = "model_vs_model"
+  sets = "diurnal_cycle",
+  short_ref_name = "v3.LR.historical_0051"
+  swap_test_ref = False
+  tag = "model_vs_model"

--- a/tests/integration/generated/test_min_case_e3sm_diags_lat_lon_land_mvm_1_chrysalis.cfg
+++ b/tests/integration/generated/test_min_case_e3sm_diags_lat_lon_land_mvm_1_chrysalis.cfg
@@ -1,0 +1,23 @@
+[default]
+case = "v3.LR.historical_0051"
+constraint = ""
+dry_run = "False"
+environment_commands = ""
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/v3.LR.historical_0051
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "/lcrc/group/e3sm/ac.forsyth2/zppy_min_case_e3sm_diags_lat_lon_land_mvm_1_output/unique_id/v2.LR.historical_0201"
+partition = "debug"
+qos = "regular"
+www = "/lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_min_case_e3sm_diags_lat_lon_land_mvm_1_www/unique_id"
+years = "1985:1989:4",
+
+[climo]
+active = True
+walltime = "00:30:00"
+
+  [[ land_monthly_climo ]]
+  frequency = "monthly"
+  input_files = "elm.h0"
+  input_subdir = "archive/lnd/hist"
+  vars = ""

--- a/tests/integration/generated/test_min_case_e3sm_diags_lat_lon_land_mvm_2_chrysalis.cfg
+++ b/tests/integration/generated/test_min_case_e3sm_diags_lat_lon_land_mvm_2_chrysalis.cfg
@@ -1,0 +1,49 @@
+[default]
+case = "v3.LR.historical_0051"
+constraint = ""
+dry_run = "False"
+environment_commands = ""
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/v3.LR.historical_0051
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "/lcrc/group/e3sm/ac.forsyth2/zppy_min_case_e3sm_diags_lat_lon_land_mvm_2_output/unique_id/v2.LR.historical_0201"
+partition = "debug"
+qos = "regular"
+www = "/lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_min_case_e3sm_diags_lat_lon_land_mvm_2_www/unique_id"
+years = "1995:1999:4",
+
+[climo]
+active = True
+walltime = "00:30:00"
+
+  [[ land_monthly_climo ]]
+  frequency = "monthly"
+  input_files = "elm.h0"
+  input_subdir = "archive/lnd/hist"
+  vars = ""
+
+[e3sm_diags]
+active = True
+grid = '180x360_aave'
+multiprocessing = True
+num_workers = 8
+partition = "compute"
+qos = "regular"
+short_name = "v3.LR.historical_0051"
+walltime = "5:00:00"
+
+  [[ lnd_monthly_mvm_lnd ]]
+  climo_subsection = "land_monthly_climo"
+  diff_title = "Difference"
+  ref_final_yr = 1988
+  ref_name = "v3.LR.historical_0051"
+  ref_start_yr = 1985
+  ref_years = "1985-1988",
+  # Use _1 as reference
+  reference_data_path = "/lcrc/group/e3sm/ac.forsyth2/zppy_min_case_e3sm_diags_lat_lon_land_mvm_1_output/unique_id/v3.LR.historical_0051/post/lnd/180x360_aave/clim"
+  run_type = "model_vs_model"
+  sets = "lat_lon_land",
+  short_ref_name = "v3.LR.historical_0051"
+  swap_test_ref = False
+  tag = "model_vs_model"
+  ts_num_years_ref = 4

--- a/tests/integration/generated/test_min_case_e3sm_diags_streamflow_chrysalis.cfg
+++ b/tests/integration/generated/test_min_case_e3sm_diags_streamflow_chrysalis.cfg
@@ -1,0 +1,41 @@
+[default]
+case = "v3.LR.historical_0051"
+constraint = ""
+dry_run = "False"
+environment_commands = ""
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/v3.LR.historical_0051
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "/lcrc/group/e3sm/ac.forsyth2/zppy_min_case_e3sm_diags_streamflow_output/unique_id/v2.LR.historical_0201"
+partition = "debug"
+qos = "regular"
+www = "/lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_min_case_e3sm_diags_streamflow_www/unique_id"
+years = "1985:1989:4",
+
+[ts]
+active = True
+e3sm_to_cmip_environment_commands = ""
+walltime = "00:30:00"
+
+  [[ rof_monthly ]]
+  extra_vars = 'areatotal2'
+  frequency = "monthly"
+  input_files = "mosart.h0"
+  input_subdir = "archive/rof/hist"
+  mapping_file = ""
+  vars = "RIVER_DISCHARGE_OVER_LAND_LIQ"
+
+[e3sm_diags]
+active = True
+grid = '180x360_aave'
+multiprocessing = True
+num_workers = 8
+partition = "compute"
+qos = "regular"
+short_name = "v3.LR.historical_0051"
+ts_num_years = 4
+walltime = "5:00:00"
+
+  [[ atm_monthly_180x360_aave ]]
+  sets = "streamflow",
+  # streamflow_obs_ts is determined automatically

--- a/tests/integration/generated/test_min_case_e3sm_diags_streamflow_mvm_1_chrysalis.cfg
+++ b/tests/integration/generated/test_min_case_e3sm_diags_streamflow_mvm_1_chrysalis.cfg
@@ -1,0 +1,26 @@
+[default]
+case = "v3.LR.historical_0051"
+constraint = ""
+dry_run = "False"
+environment_commands = ""
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/v3.LR.historical_0051
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "/lcrc/group/e3sm/ac.forsyth2/zppy_min_case_e3sm_diags_streamflow_mvm_1_output/unique_id/v2.LR.historical_0201"
+partition = "debug"
+qos = "regular"
+www = "/lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_min_case_e3sm_diags_streamflow_mvm_1_www/unique_id"
+years = "1985:1989:4",
+
+[ts]
+active = True
+e3sm_to_cmip_environment_commands = ""
+walltime = "00:30:00"
+
+  [[ rof_monthly ]]
+  extra_vars = 'areatotal2'
+  frequency = "monthly"
+  input_files = "mosart.h0"
+  input_subdir = "archive/rof/hist"
+  mapping_file = ""
+  vars = "RIVER_DISCHARGE_OVER_LAND_LIQ"

--- a/tests/integration/generated/test_min_case_e3sm_diags_streamflow_mvm_2_chrysalis.cfg
+++ b/tests/integration/generated/test_min_case_e3sm_diags_streamflow_mvm_2_chrysalis.cfg
@@ -1,0 +1,55 @@
+[default]
+case = "v3.LR.historical_0051"
+constraint = ""
+dry_run = "False"
+environment_commands = ""
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/v3.LR.historical_0051
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "/lcrc/group/e3sm/ac.forsyth2/zppy_min_case_e3sm_diags_streamflow_mvm_2_output/unique_id/v2.LR.historical_0201"
+partition = "debug"
+qos = "regular"
+www = "/lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_min_case_e3sm_diags_streamflow_mvm_2_www/unique_id"
+years = "1995:1999:4",
+
+[ts]
+active = True
+e3sm_to_cmip_environment_commands = ""
+walltime = "00:30:00"
+
+  [[ rof_monthly ]]
+  extra_vars = 'areatotal2'
+  frequency = "monthly"
+  input_files = "mosart.h0"
+  input_subdir = "archive/rof/hist"
+  mapping_file = ""
+  vars = "RIVER_DISCHARGE_OVER_LAND_LIQ"
+
+[e3sm_diags]
+active = True
+grid = '180x360_aave'
+multiprocessing = True
+num_workers = 8
+partition = "compute"
+qos = "regular"
+short_name = "v3.LR.historical_0051"
+ts_num_years = 4
+walltime = "5:00:00"
+
+  [[ atm_monthly_180x360_aave_mvm ]]
+  # Test model-vs-model using the same files as the reference
+  diff_title = "Difference"
+  ref_final_yr = 1988
+  ref_name = "#expand_case_name#"
+  ref_start_yr = 1985
+  ref_years = "1985-1988",
+  # Use _1 as reference
+  reference_data_path = "/lcrc/group/e3sm/ac.forsyth2/zppy_min_case_e3sm_diags_streamflow_mvm_1_output/unique_id/v3.LR.historical_0051/post/atm/180x360_aave/clim"
+  # reference_data_path_ts_rof determined automatically
+  run_type = "model_vs_model"
+  sets="streamflow"
+  short_ref_name = "#expand_case_name#"
+  swap_test_ref = False
+  tag = "model_vs_model"
+  ts_num_years_ref = 4
+  years = "1995-1998",

--- a/tests/integration/generated/test_min_case_e3sm_diags_tc_analysis_chrysalis.cfg
+++ b/tests/integration/generated/test_min_case_e3sm_diags_tc_analysis_chrysalis.cfg
@@ -1,0 +1,34 @@
+[default]
+case = "v3.LR.historical_0051"
+constraint = ""
+dry_run = "False"
+environment_commands = ""
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/v3.LR.historical_0051
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "/lcrc/group/e3sm/ac.forsyth2/zppy_min_case_e3sm_diags_tc_analysis_output/unique_id/v2.LR.historical_0201"
+partition = "debug"
+qos = "regular"
+www = "/lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_min_case_e3sm_diags_tc_analysis_www/unique_id"
+years = "1985:1987:2",
+
+[tc_analysis]
+active = True
+scratch = "/lcrc/globalscratch/ac.forsyth2/"
+walltime = "00:30:00"
+
+[e3sm_diags]
+active = True
+grid = '180x360_aave'
+multiprocessing = True
+num_workers = 8
+partition = "compute"
+qos = "regular"
+short_name = "v3.LR.historical_0051"
+ts_num_years = 2
+walltime = "5:00:00"
+
+  [[ atm_monthly_180x360_aave_tc_analysis ]]
+  # Note: tc_analysis requires e3sm_diags jobs to run sequentially
+  sets = "tc_analysis",
+  # tc_obs is determined automatically

--- a/tests/integration/generated/test_min_case_e3sm_diags_tc_analysis_mvm_1_chrysalis.cfg
+++ b/tests/integration/generated/test_min_case_e3sm_diags_tc_analysis_mvm_1_chrysalis.cfg
@@ -1,0 +1,18 @@
+[default]
+case = "v3.LR.historical_0051"
+constraint = ""
+dry_run = "False"
+environment_commands = ""
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/v3.LR.historical_0051
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "/lcrc/group/e3sm/ac.forsyth2/zppy_min_case_e3sm_diags_tc_analysis_mvm_1_output/unique_id/v2.LR.historical_0201"
+partition = "debug"
+qos = "regular"
+www = "/lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_min_case_e3sm_diags_tc_analysis_mvm_2_www/unique_id"
+years = "1985:1987:2",
+
+[tc_analysis]
+active = True
+scratch = "/lcrc/globalscratch/ac.forsyth2/"
+walltime = "00:30:00"

--- a/tests/integration/generated/test_min_case_e3sm_diags_tc_analysis_mvm_2_chrysalis.cfg
+++ b/tests/integration/generated/test_min_case_e3sm_diags_tc_analysis_mvm_2_chrysalis.cfg
@@ -1,0 +1,46 @@
+[default]
+case = "v3.LR.historical_0051"
+constraint = ""
+dry_run = "False"
+environment_commands = ""
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/v3.LR.historical_0051
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "/lcrc/group/e3sm/ac.forsyth2/zppy_min_case_e3sm_diags_tc_analysis_mvm_2_output/unique_id/v2.LR.historical_0201"
+partition = "debug"
+qos = "regular"
+www = "/lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_min_case_e3sm_diags_tc_analysis_mvm_2_www/unique_id"
+years = "1995:1997:2",
+
+[tc_analysis]
+active = True
+scratch = "/lcrc/globalscratch/ac.forsyth2/"
+walltime = "00:30:00"
+
+[e3sm_diags]
+active = True
+grid = '180x360_aave'
+multiprocessing = True
+num_workers = 8
+partition = "compute"
+qos = "regular"
+short_name = "v3.LR.historical_0051"
+walltime = "5:00:00"
+
+    [[ atm_monthly_180x360_aave_mvm ]]
+  # Test model-vs-model using the same files as the reference
+  climo_subsection = "atm_monthly_180x360_aave"
+  diff_title = "Difference"
+  ref_final_yr = 1986
+  ref_name = "v3.LR.historical_0051"
+  ref_start_yr = 1985
+  ref_years = "1985-1986",
+  # Use _1 as reference
+  reference_data_path = "/lcrc/group/e3sm/ac.forsyth2/zppy_min_case_e3sm_diags_tc_analysis_mvm_1_output/unique_id/v3.LR.historical_0051/post/atm/180x360_aave/clim"
+  # reference_data_path_tc determined automatically
+  run_type = "model_vs_model"
+  sets = "tc_analysis",
+  short_ref_name = "v3.LR.historical_0051"
+  swap_test_ref = False
+  tag = "model_vs_model"
+  years = "1995-1996",

--- a/tests/integration/generated/test_min_case_e3sm_diags_tropical_subseasonal_chrysalis.cfg
+++ b/tests/integration/generated/test_min_case_e3sm_diags_tropical_subseasonal_chrysalis.cfg
@@ -1,0 +1,38 @@
+[default]
+case = "v3.LR.historical_0051"
+constraint = ""
+dry_run = "False"
+environment_commands = ""
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/v3.LR.historical_0051
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "/lcrc/group/e3sm/ac.forsyth2/zppy_min_case_e3sm_diags_tropical_subseasonal_output/unique_id/v2.LR.historical_0201"
+partition = "debug"
+qos = "regular"
+www = "/lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_min_case_e3sm_diags_tropical_subseasonal_www/unique_id"
+years = "1985:1989:4",
+
+[ts]
+active = True
+e3sm_to_cmip_environment_commands = ""
+walltime = "00:30:00"
+
+  [[ atm_daily_180x360_aave ]]
+  frequency = "daily"
+  input_files = "eam.h1"
+  input_subdir = "archive/atm/hist"
+  vars = "PRECT"
+
+[e3sm_diags]
+active = True
+grid = '180x360_aave'
+multiprocessing = True
+num_workers = 8
+partition = "compute"
+qos = "regular"
+short_name = "v3.LR.historical_0051"
+ts_num_years = 4
+walltime = "5:00:00"
+
+  [[ atm_monthly_180x360_aave ]]
+  sets = "tropical_subseasonal",

--- a/tests/integration/generated/test_min_case_e3sm_diags_tropical_subseasonal_mvm_1_chrysalis.cfg
+++ b/tests/integration/generated/test_min_case_e3sm_diags_tropical_subseasonal_mvm_1_chrysalis.cfg
@@ -1,0 +1,24 @@
+[default]
+case = "v3.LR.historical_0051"
+constraint = ""
+dry_run = "False"
+environment_commands = ""
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/v3.LR.historical_0051
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "/lcrc/group/e3sm/ac.forsyth2/zppy_min_case_e3sm_diags_tropical_subseasonal_mvm_1_output/unique_id/v2.LR.historical_0201"
+partition = "debug"
+qos = "regular"
+www = "/lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_min_case_e3sm_diags_tropical_subseasonal_mvm_1_www/unique_id"
+years = "1985:1989:4",
+
+[ts]
+active = True
+e3sm_to_cmip_environment_commands = ""
+walltime = "00:30:00"
+
+  [[ atm_daily_180x360_aave ]]
+  frequency = "daily"
+  input_files = "eam.h1"
+  input_subdir = "archive/atm/hist"
+  vars = "PRECT"

--- a/tests/integration/generated/test_min_case_e3sm_diags_tropical_subseasonal_mvm_2_chrysalis.cfg
+++ b/tests/integration/generated/test_min_case_e3sm_diags_tropical_subseasonal_mvm_2_chrysalis.cfg
@@ -1,0 +1,55 @@
+[default]
+case = "v3.LR.historical_0051"
+constraint = ""
+dry_run = "False"
+environment_commands = ""
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/v3.LR.historical_0051
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "/lcrc/group/e3sm/ac.forsyth2/zppy_min_case_e3sm_diags_tropical_subseasonal_mvm_2_output/unique_id/v2.LR.historical_0201"
+partition = "debug"
+qos = "regular"
+www = "/lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_min_case_e3sm_diags_tropical_subseasonal_mvm_2_www/unique_id"
+years = "1995:1999:4",
+
+[ts]
+active = True
+e3sm_to_cmip_environment_commands = ""
+walltime = "00:30:00"
+
+  [[ atm_daily_180x360_aave ]]
+  frequency = "daily"
+  input_files = "eam.h1"
+  input_subdir = "archive/atm/hist"
+  vars = "PRECT"
+
+[e3sm_diags]
+active = True
+grid = '180x360_aave'
+multiprocessing = True
+num_workers = 8
+partition = "compute"
+qos = "regular"
+short_name = "v3.LR.historical_0051"
+ts_num_years = 4
+walltime = "5:00:00"
+
+  [[ atm_monthly_180x360_aave_mvm ]]
+  # Test model-vs-model using the same files as the reference
+  climo_subsection = "atm_monthly_180x360_aave"
+  diff_title = "Difference"
+  ref_final_yr = 1988
+  ref_name = "v3.LR.historical_0051"
+  ref_start_yr = 1985
+  ref_years = "1985-1988",
+  # Use _1 as reference
+  reference_data_path = "/lcrc/group/e3sm/ac.forsyth2/zppy_min_case_e3sm_diags_tropical_subseasonal_mvm_1_output/unique_id/v3.LR.historical_0051/post/atm/180x360_aave/clim"
+  # reference_data_path_daily is determined automatically
+  run_type = "model_vs_model"
+  sets = "tropical_subseasonal",
+  short_ref_name = "v3.LR.historical_0051"
+  swap_test_ref = False
+  tag = "model_vs_model"
+  ts_num_years_ref = 4
+  ts_subsection = "atm_monthly_180x360_aave"
+  years = "1995-1998",

--- a/tests/integration/generated/test_min_case_global_time_series_custom_chrysalis.cfg
+++ b/tests/integration/generated/test_min_case_global_time_series_custom_chrysalis.cfg
@@ -1,0 +1,44 @@
+[default]
+case = "v3.LR.historical_0051"
+constraint = ""
+dry_run = "False"
+environment_commands = ""
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/v3.LR.historical_0051
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "/lcrc/group/e3sm/ac.forsyth2/zppy_min_case_global_time_series_custom_output/unique_id/v2.LR.historical_0201"
+partition = "debug"
+qos = "regular"
+www = "/lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_min_case_global_time_series_custom_www/unique_id"
+
+[ts]
+active = True
+e3sm_to_cmip_environment_commands = ""
+walltime = "00:30:00"
+years = "1985:1995:5",
+
+  [[ atm_monthly_glb ]]
+  # Note global average won't work for 3D variables.
+  frequency = "monthly"
+  input_files = "eam.h0"
+  input_subdir = "archive/atm/hist"
+  mapping_file = "glb"
+  vars = "TREFHT,AODDUST"
+
+  [[ lnd_monthly_glb ]]
+  frequency = "monthly"
+  input_files = "elm.h0"
+  input_subdir = "archive/lnd/hist"
+  mapping_file = "glb"
+  vars = "FSH,RH2M,LAISHA,LAISUN,QINTR,QOVER,QRUNOFF,QSOIL,QVEGE,QVEGT,SOILWATER_10CM,TSA,H2OSNO,TOTLITC,CWDC,SOIL1C,SOIL2C,SOIL3C,SOIL4C,WOOD_HARVESTC,TOTVEGC,NBP,GPP,AR,HR"
+
+[global_time_series]
+active = True
+experiment_name = "v3.LR.historical_0051"
+figstr = "v3.LR.historical_0051"
+plots_original=""
+plots_atm = "TREFHT,AODDUST"
+plots_lnd = "FSH,RH2M,LAISHA,LAISUN,QINTR,QOVER,QRUNOFF,QSOIL,QVEGE,QVEGT,SOILWATER_10CM,TSA,H2OSNO,TOTLITC,CWDC,SOIL1C,SOIL2C,SOIL3C,SOIL4C,WOOD_HARVESTC,TOTVEGC,NBP,GPP,AR,HR"
+ts_num_years = 5
+walltime = "00:30:00"
+years = "1985-1995",

--- a/tests/integration/generated/test_min_case_global_time_series_original_8_chrysalis.cfg
+++ b/tests/integration/generated/test_min_case_global_time_series_original_8_chrysalis.cfg
@@ -1,0 +1,49 @@
+[default]
+case = "v3.LR.historical_0051"
+constraint = ""
+dry_run = "False"
+environment_commands = ""
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/v3.LR.historical_0051
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "/lcrc/group/e3sm/ac.forsyth2/zppy_min_case_global_time_series_original_8_output/unique_id/v2.LR.historical_0201"
+partition = "debug"
+qos = "regular"
+www = "/lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_min_case_global_time_series_original_8_www/unique_id"
+
+[ts]
+active = True
+e3sm_to_cmip_environment_commands = ""
+walltime = "00:30:00"
+
+  [[ atm_monthly_glb ]]
+  # Note global average won't work for 3D variables.
+  frequency = "monthly"
+  input_files = "eam.h0"
+  input_subdir = "archive/atm/hist"
+  mapping_file = "glb"
+  years = "1985:1995:5",
+
+[mpas_analysis]
+active = True
+anomalyRefYear = 1985
+climo_years = "1985-1989", "1990-1995",
+enso_years = "1985-1989", "1990-1995",
+mesh = "IcoswISC30E3r5"
+parallelTaskCount = 6
+partition = "compute"
+qos = "regular"
+shortTermArchive = True
+ts_years = "1985-1989", "1985-1995",
+walltime = "00:30:00"
+
+[global_time_series]
+active = True
+climo_years = "1985-1989", "1990-1995",
+experiment_name = "v3.LR.historical_0051"
+figstr = "v3.LR.historical_0051"
+moc_file=mocTimeSeries_1985-1995.nc
+ts_num_years = 5
+ts_years = "1985-1989", "1985-1995",
+walltime = "00:30:00"
+years = "1985-1995",

--- a/tests/integration/generated/test_min_case_global_time_series_original_8_no_ocn_chrysalis.cfg
+++ b/tests/integration/generated/test_min_case_global_time_series_original_8_no_ocn_chrysalis.cfg
@@ -1,0 +1,34 @@
+[default]
+case = "v3.LR.historical_0051"
+constraint = ""
+dry_run = "False"
+environment_commands = ""
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/v3.LR.historical_0051
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "/lcrc/group/e3sm/ac.forsyth2/zppy_min_case_global_time_series_original_8_no_ocn_output/unique_id/v2.LR.historical_0201"
+partition = "debug"
+qos = "regular"
+www = "/lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_min_case_global_time_series_original_8_no_ocn_www/unique_id"
+
+[ts]
+active = True
+e3sm_to_cmip_environment_commands = ""
+walltime = "00:30:00"
+
+  [[ atm_monthly_glb ]]
+  # Note global average won't work for 3D variables.
+  frequency = "monthly"
+  input_files = "eam.h0"
+  input_subdir = "archive/atm/hist"
+  mapping_file = "glb"
+  years = "1985:1995:5",
+
+[global_time_series]
+active = True
+experiment_name = "v3.LR.historical_0051"
+figstr = "v3.LR.historical_0051"
+plots_original="net_toa_flux_restom,global_surface_air_temperature,toa_radiation,net_atm_energy_imbalance,change_ohc,max_moc,change_sea_level,net_atm_water_imbalance"
+ts_num_years = 5
+walltime = "00:30:00"
+years = "1985-1995",

--- a/tests/integration/generated/test_min_case_ilamb_chrysalis.cfg
+++ b/tests/integration/generated/test_min_case_ilamb_chrysalis.cfg
@@ -1,0 +1,42 @@
+[default]
+case = "v3.LR.historical_0051"
+constraint = ""
+dry_run = "False"
+environment_commands = ""
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/v3.LR.historical_0051
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "/lcrc/group/e3sm/ac.forsyth2/zppy_min_case_ilamb_output/unique_id/v2.LR.historical_0201"
+partition = "debug"
+qos = "regular"
+www = "/lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_min_case_ilamb_www/unique_id"
+
+[ts]
+active = True
+e3sm_to_cmip_environment_commands = ""
+walltime = "00:50:00"
+ts_fmt = "cmip"
+years = "1985:2014:30"
+
+  [[ atm_monthly_180x360_aave ]]
+  frequency = "monthly"
+  input_files = "eam.h0"
+  input_subdir = "archive/atm/hist"
+  vars = "FSNTOA,FLUT,FSNT,FLNT,FSNS,FLNS,SHFLX,QFLX,TAUX,TAUY,PRECC,PRECL,PRECSC,PRECSL,TS,TREFHT,CLDTOT,CLDHGH,CLDMED,CLDLOW,U,ICEFRAC,LANDFRAC,OCNFRAC,PS,CLDICE,CLDLIQ,T,AODDUST"
+
+  [[ land_monthly ]]
+  extra_vars = "landfrac"
+  frequency = "monthly"
+  input_files = "elm.h0"
+  input_subdir = "archive/lnd/hist"
+  mapping_file = "map_r05_to_cmip6_180x360_aave.20231110.nc"
+  vars = "FSH,RH2M,LAISHA,LAISUN,QINTR,QOVER,QRUNOFF,QSOIL,QVEGE,QVEGT,SOILICE,SOILLIQ,SOILWATER_10CM,TSA,TSOI,H2OSNO,TOTLITC,CWDC,SOIL1C,SOIL2C,SOIL3C,SOIL4C,WOOD_HARVESTC,TOTVEGC,NBP,GPP,AR,HR"
+
+[ilamb]
+active = True
+nodes = 8
+partition = "compute"
+short_name = "v3.LR.historical_0051"
+ts_num_years = 30
+walltime = "2:00:00"
+years = "1985:2014:30"

--- a/tests/integration/generated/test_min_case_ilamb_land_only_chrysalis.cfg
+++ b/tests/integration/generated/test_min_case_ilamb_land_only_chrysalis.cfg
@@ -1,0 +1,37 @@
+[default]
+case = "v3.LR.historical_0051"
+constraint = ""
+dry_run = "False"
+environment_commands = ""
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/v3.LR.historical_0051
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "/lcrc/group/e3sm/ac.forsyth2/zppy_min_case_ilamb_land_only_output/unique_id/v2.LR.historical_0201"
+partition = "debug"
+qos = "regular"
+www = "/lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_min_case_ilamb_land_only_www/unique_id"
+
+[ts]
+active = True
+e3sm_to_cmip_environment_commands = ""
+walltime = "00:50:00"
+ts_fmt = "cmip"
+years = "1985:2014:30"
+
+  [[ land_monthly ]]
+  extra_vars = "landfrac"
+  frequency = "monthly"
+  input_files = "elm.h0"
+  input_subdir = "archive/lnd/hist"
+  mapping_file = "map_r05_to_cmip6_180x360_aave.20231110.nc"
+  vars = "FSH,RH2M,LAISHA,LAISUN,QINTR,QOVER,QRUNOFF,QSOIL,QVEGE,QVEGT,SOILICE,SOILLIQ,SOILWATER_10CM,TSA,TSOI,H2OSNO,TOTLITC,CWDC,SOIL1C,SOIL2C,SOIL3C,SOIL4C,WOOD_HARVESTC,TOTVEGC,NBP,GPP,AR,HR"
+
+[ilamb]
+active = True
+land_only = True
+nodes = 8
+partition = "compute"
+short_name = "v3.LR.historical_0051"
+ts_num_years = 30
+walltime = "2:00:00"
+years = "1985:2014:30"

--- a/tests/integration/generated/test_min_case_mpas_analysis_chrysalis.cfg
+++ b/tests/integration/generated/test_min_case_mpas_analysis_chrysalis.cfg
@@ -1,0 +1,25 @@
+[default]
+case = "v3.LR.historical_0051"
+constraint = ""
+dry_run = "False"
+environment_commands = ""
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/v3.LR.historical_0051
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "/lcrc/group/e3sm/ac.forsyth2/zppy_min_case_mpas_analysis_output/unique_id/v2.LR.historical_0201"
+partition = "debug"
+qos = "regular"
+www = "/lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_min_case_mpas_analysis_www/unique_id"
+
+[mpas_analysis]
+active = True
+anomalyRefYear = 1985
+climo_years = "1985-1989", "1990-1995",
+enso_years = "1985-1989", "1990-1995",
+mesh = "IcoswISC30E3r5"
+parallelTaskCount = 6
+partition = "compute"
+qos = "regular"
+shortTermArchive = True
+ts_years = "1985-1989", "1985-1995",
+walltime = "00:30:00"

--- a/tests/integration/run_min_cases.sh
+++ b/tests/integration/run_min_cases.sh
@@ -1,0 +1,13 @@
+# Edit the list below to list the min cases you think would be affected by your code changes:
+min_cases=("1st min case" "2nd min case")
+
+# Edit this to be the machine you're on
+machine=chrysalis
+
+pip install . && python tests/integration/utils.py
+for min_case in "${min_cases[@]}"
+do
+  zppy -c tests/integration/generated/test_min_case_${min_case}_${machine}.cfg
+done
+
+# For two-cfg cases, you'll need to run the _2 cfgs after the _1 cfgs' jobs have finished.

--- a/tests/integration/template_directions.md
+++ b/tests/integration/template_directions.md
@@ -145,3 +145,12 @@ cp -r #expand user_output#zppy_test_bundles_output/<UNIQUE ID>/v2.LR.historical_
 ```
 cp -r #expand user_www#zppy_test_complete_run_www/<UNIQUE ID>/v2.LR.historical_0201 #expand expected_dir#expected_complete_run_unified_<#>
 ```
+
+## Minimal Cases
+
+Some tests specifically check minimal zppy cfgs:
+i.e., cfgs with as few parameters as possible to test a specific case.
+If your code changes could interact with these minimal cases,
+then you should run the relevant ones to make sure they still work.
+
+Read and run `tests/integration/run_min_cases.sh`.

--- a/tests/integration/template_min_case_e3sm_diags_depend_on_climo.cfg
+++ b/tests/integration/template_min_case_e3sm_diags_depend_on_climo.cfg
@@ -1,0 +1,37 @@
+[default]
+case = "#expand case_name#"
+constraint = "#expand constraint#"
+dry_run = "#expand dry_run#"
+environment_commands = "#expand environment_commands#"
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/#expand case_name#
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "#expand user_output#zppy_min_case_e3sm_diags_depend_on_climo_output/#expand unique_id#/v2.LR.historical_0201"
+partition = "#expand partition_short#"
+qos = "#expand qos_short#"
+www = "#expand user_www#zppy_min_case_e3sm_diags_depend_on_climo_www/#expand unique_id#"
+years = "1985:1989:4",
+
+[climo]
+active = True
+walltime = "00:30:00"
+
+  [[ atm_monthly_180x360_aave ]]
+  frequency = "monthly"
+  input_files = "eam.h0"
+  input_subdir = "archive/atm/hist"
+  vars = ""
+
+[e3sm_diags]
+active = True
+grid = '180x360_aave'
+multiprocessing = True
+num_workers = 8
+partition = "#expand partition_long#"
+qos = "#expand qos_long#"
+short_name = "#expand case_name#"
+walltime = "#expand diags_walltime#"
+
+  [[ atm_monthly_180x360_aave ]]
+  climo_subsection = "atm_monthly_180x360_aave"
+  sets = "lat_lon","zonal_mean_xy","zonal_mean_2d","polar","cosp_histogram","meridional_mean_2d","annual_cycle_zonal_mean","zonal_mean_2d_stratosphere",

--- a/tests/integration/template_min_case_e3sm_diags_depend_on_climo_mvm_1.cfg
+++ b/tests/integration/template_min_case_e3sm_diags_depend_on_climo_mvm_1.cfg
@@ -1,0 +1,23 @@
+[default]
+case = "#expand case_name#"
+constraint = "#expand constraint#"
+dry_run = "#expand dry_run#"
+environment_commands = "#expand environment_commands#"
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/#expand case_name#
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "#expand user_output#zppy_min_case_e3sm_diags_depend_on_climo_mvm_1_output/#expand unique_id#/v2.LR.historical_0201"
+partition = "#expand partition_short#"
+qos = "#expand qos_short#"
+www = "#expand user_www#zppy_min_case_e3sm_diags_depend_on_climo_mvm_1_www/#expand unique_id#"
+years = "1985:1989:4",
+
+[climo]
+active = True
+walltime = "00:30:00"
+
+  [[ atm_monthly_180x360_aave ]]
+  frequency = "monthly"
+  input_files = "eam.h0"
+  input_subdir = "archive/atm/hist"
+  vars = ""

--- a/tests/integration/template_min_case_e3sm_diags_depend_on_climo_mvm_2.cfg
+++ b/tests/integration/template_min_case_e3sm_diags_depend_on_climo_mvm_2.cfg
@@ -1,0 +1,52 @@
+[default]
+case = "#expand case_name#"
+constraint = "#expand constraint#"
+dry_run = "#expand dry_run#"
+environment_commands = "#expand environment_commands#"
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/#expand case_name#
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "#expand user_output#zppy_min_case_e3sm_diags_depend_on_climo_mvm_2_output/#expand unique_id#/v2.LR.historical_0201"
+partition = "#expand partition_short#"
+qos = "#expand qos_short#"
+www = "#expand user_www#zppy_min_case_e3sm_diags_depend_on_climo_mvm_2_www/#expand unique_id#"
+years = "1995:1999:4",
+
+[climo]
+active = True
+walltime = "00:30:00"
+
+  [[ atm_monthly_180x360_aave ]]
+  frequency = "monthly"
+  input_files = "eam.h0"
+  input_subdir = "archive/atm/hist"
+  vars = ""
+
+[e3sm_diags]
+active = True
+grid = '180x360_aave'
+multiprocessing = True
+num_workers = 8
+partition = "#expand partition_long#"
+qos = "#expand qos_long#"
+short_name = "#expand case_name#"
+walltime = "#expand diags_walltime#"
+
+  [[ atm_monthly_180x360_aave_mvm ]]
+  # Test model-vs-model using the same files as the reference
+  climo_subsection = "atm_monthly_180x360_aave"
+  diff_title = "Difference"
+  ref_final_yr = 1988
+  ref_name = "#expand case_name#"
+  ref_start_yr = 1985
+  ref_years = "1985-1988",
+  # Use _1 as reference
+  reference_data_path = "#expand user_output#zppy_min_case_e3sm_diags_depend_on_climo_mvm_1_output/#expand unique_id#/#expand case_name#/post/atm/180x360_aave/clim"
+  run_type = "model_vs_model"
+  sets = "lat_lon","zonal_mean_xy","zonal_mean_2d","polar","cosp_histogram","meridional_mean_2d","annual_cycle_zonal_mean","zonal_mean_2d_stratosphere",
+  short_ref_name = "#expand case_name#"
+  swap_test_ref = False
+  tag = "model_vs_model"
+  ts_num_years_ref = 4
+  ts_subsection = "atm_monthly_180x360_aave"
+  years = "1995-1998",

--- a/tests/integration/template_min_case_e3sm_diags_depend_on_ts.cfg
+++ b/tests/integration/template_min_case_e3sm_diags_depend_on_ts.cfg
@@ -1,0 +1,38 @@
+[default]
+case = "#expand case_name#"
+constraint = "#expand constraint#"
+dry_run = "#expand dry_run#"
+environment_commands = "#expand environment_commands#"
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/#expand case_name#
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "#expand user_output#zppy_min_case_e3sm_diags_depend_on_ts_output/#expand unique_id#/v2.LR.historical_0201"
+partition = "#expand partition_short#"
+qos = "#expand qos_short#"
+www = "#expand user_www#zppy_min_case_e3sm_diags_depend_on_ts_www/#expand unique_id#"
+years = "1985:1989:4",
+
+[ts]
+active = True
+e3sm_to_cmip_environment_commands = "#expand e3sm_to_cmip_environment_commands#"
+walltime = "00:30:00"
+
+  [[ atm_monthly_180x360_aave ]]
+  frequency = "monthly"
+  input_files = "eam.h0"
+  input_subdir = "archive/atm/hist"
+  #ts_fmt = "cmip"
+
+[e3sm_diags]
+active = True
+grid = '180x360_aave'
+multiprocessing = True
+num_workers = 8
+partition = "#expand partition_long#"
+qos = "#expand qos_long#"
+short_name = "#expand case_name#"
+ts_num_years = 4
+walltime = "#expand diags_walltime#"
+
+  [[ atm_monthly_180x360_aave ]]
+  sets = "enso_diags","qbo",

--- a/tests/integration/template_min_case_e3sm_diags_depend_on_ts_mvm_1.cfg
+++ b/tests/integration/template_min_case_e3sm_diags_depend_on_ts_mvm_1.cfg
@@ -1,0 +1,24 @@
+[default]
+case = "#expand case_name#"
+constraint = "#expand constraint#"
+dry_run = "#expand dry_run#"
+environment_commands = "#expand environment_commands#"
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/#expand case_name#
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "#expand user_output#zppy_min_case_e3sm_diags_depend_on_ts_mvm_1_output/#expand unique_id#/v2.LR.historical_0201"
+partition = "#expand partition_short#"
+qos = "#expand qos_short#"
+www = "#expand user_www#zppy_min_case_e3sm_diags_depend_on_ts_mvm_1_www/#expand unique_id#"
+years = "1985:1989:4",
+
+[ts]
+active = True
+e3sm_to_cmip_environment_commands = "#expand e3sm_to_cmip_environment_commands#"
+walltime = "00:30:00"
+
+  [[ atm_monthly_180x360_aave ]]
+  frequency = "monthly"
+  input_files = "eam.h0"
+  input_subdir = "archive/atm/hist"
+  #ts_fmt = "cmip"

--- a/tests/integration/template_min_case_e3sm_diags_depend_on_ts_mvm_2.cfg
+++ b/tests/integration/template_min_case_e3sm_diags_depend_on_ts_mvm_2.cfg
@@ -1,0 +1,55 @@
+[default]
+case = "#expand case_name#"
+constraint = "#expand constraint#"
+dry_run = "#expand dry_run#"
+environment_commands = "#expand environment_commands#"
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/#expand case_name#
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "#expand user_output#zppy_min_case_e3sm_diags_depend_on_ts_mvm_2_output/#expand unique_id#/v2.LR.historical_0201"
+partition = "#expand partition_short#"
+qos = "#expand qos_short#"
+www = "#expand user_www#zppy_min_case_e3sm_diags_depend_on_ts_mvm_2_www/#expand unique_id#"
+years = "1995:1999:4",
+
+[ts]
+active = True
+e3sm_to_cmip_environment_commands = "#expand e3sm_to_cmip_environment_commands#"
+walltime = "00:30:00"
+
+  [[ atm_monthly_180x360_aave ]]
+  frequency = "monthly"
+  input_files = "eam.h0"
+  input_subdir = "archive/atm/hist"
+  #ts_fmt = "cmip"
+
+[e3sm_diags]
+active = True
+grid = '180x360_aave'
+multiprocessing = True
+num_workers = 8
+partition = "#expand partition_long#"
+qos = "#expand qos_long#"
+short_name = "#expand case_name#"
+ts_num_years = 4
+walltime = "#expand diags_walltime#"
+
+  [[ atm_monthly_180x360_aave_mvm ]]
+  # Test model-vs-model using the same files as the reference
+  climo_subsection = "atm_monthly_180x360_aave"
+  diff_title = "Difference"
+  ref_final_yr = 1988
+  ref_name = "#expand case_name#"
+  ref_start_yr = 1985
+  ref_years = "1985-1988",
+  # Use _1 as reference
+  reference_data_path = "#expand user_output#zppy_min_case_e3sm_diags_depend_on_ts_mvm_1_output/#expand unique_id#/#expand case_name#/post/atm/180x360_aave/clim"
+  run_type = "model_vs_model"
+  sets = "enso_diags","qbo",
+  short_ref_name = "#expand case_name#"
+  swap_test_ref = False
+  tag = "model_vs_model"
+  ts_num_years_ref = 4
+  ts_subsection = "atm_monthly_180x360_aave"
+  walltime = "#expand diags_walltime#"
+  years = "1995-1998",

--- a/tests/integration/template_min_case_e3sm_diags_diurnal_cycle.cfg
+++ b/tests/integration/template_min_case_e3sm_diags_diurnal_cycle.cfg
@@ -1,0 +1,40 @@
+[default]
+case = "#expand case_name#"
+constraint = "#expand constraint#"
+dry_run = "#expand dry_run#"
+environment_commands = "#expand environment_commands#"
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/#expand case_name#
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "#expand user_output#zppy_min_case_e3sm_diags_diurnal_cycle_output/#expand unique_id#/v2.LR.historical_0201"
+partition = "#expand partition_short#"
+qos = "#expand qos_short#"
+www = "#expand user_www#zppy_min_case_e3sm_diags_diurnal_cycle_www/#expand unique_id#"
+years = "1985:1989:4",
+
+[climo]
+active = True
+walltime = "00:30:00"
+
+  [[ atm_monthly_diurnal_8xdaily_180x360_aave ]]
+  frequency = "diurnal_8xdaily"
+  input_files = "eam.h3"
+  input_subdir = "archive/atm/hist"
+  vars = "PRECT"
+
+[e3sm_diags]
+active = True
+grid = '180x360_aave'
+multiprocessing = True
+num_workers = 8
+partition = "#expand partition_long#"
+qos = "#expand qos_long#"
+short_name = "#expand case_name#"
+ts_num_years = 4
+walltime = "#expand diags_walltime#"
+
+  [[ atm_monthly_180x360_aave ]]
+  climo_diurnal_frequency = "diurnal_8xdaily"
+  climo_diurnal_subsection = "atm_monthly_diurnal_8xdaily_180x360_aave"
+  dc_obs_climo = '/lcrc/group/e3sm/public_html/e3sm_diags_test_data/unit_test_complete_run/obs/climatology'
+  sets = "diurnal_cycle",

--- a/tests/integration/template_min_case_e3sm_diags_diurnal_cycle_mvm_1.cfg
+++ b/tests/integration/template_min_case_e3sm_diags_diurnal_cycle_mvm_1.cfg
@@ -1,0 +1,23 @@
+[default]
+case = "#expand case_name#"
+constraint = "#expand constraint#"
+dry_run = "#expand dry_run#"
+environment_commands = "#expand environment_commands#"
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/#expand case_name#
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "#expand user_output#zppy_min_case_e3sm_diags_diurnal_cycle_mvm_1_output/#expand unique_id#/v2.LR.historical_0201"
+partition = "#expand partition_short#"
+qos = "#expand qos_short#"
+www = "#expand user_www#zppy_min_case_e3sm_diags_diurnal_cycle_mvm_1_www/#expand unique_id#"
+years = "1985:1989:4",
+
+[climo]
+active = True
+walltime = "00:30:00"
+
+  [[ atm_monthly_diurnal_8xdaily_180x360_aave ]]
+  frequency = "diurnal_8xdaily"
+  input_files = "eam.h3"
+  input_subdir = "archive/atm/hist"
+  vars = "PRECT"

--- a/tests/integration/template_min_case_e3sm_diags_diurnal_cycle_mvm_2.cfg
+++ b/tests/integration/template_min_case_e3sm_diags_diurnal_cycle_mvm_2.cfg
@@ -1,0 +1,47 @@
+[default]
+case = "#expand case_name#"
+constraint = "#expand constraint#"
+dry_run = "#expand dry_run#"
+environment_commands = "#expand environment_commands#"
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/#expand case_name#
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "#expand user_output#zppy_min_case_e3sm_diags_diurnal_cycle_mvm_2_output/#expand unique_id#/v2.LR.historical_0201"
+partition = "#expand partition_short#"
+qos = "#expand qos_short#"
+www = "#expand user_www#zppy_min_case_e3sm_diags_diurnal_cycle_mvm_2_www/#expand unique_id#"
+years = "1995:1999:4",
+
+[climo]
+active = True
+walltime = "00:30:00"
+
+  [[ atm_monthly_diurnal_8xdaily_180x360_aave ]]
+  frequency = "diurnal_8xdaily"
+  input_files = "eam.h3"
+  input_subdir = "archive/atm/hist"
+  vars = "PRECT"
+
+[e3sm_diags]
+active = True
+grid = '180x360_aave'
+multiprocessing = True
+num_workers = 8
+partition = "#expand partition_long#"
+qos = "#expand qos_long#"
+short_name = "#expand case_name#"
+walltime = "#expand diags_walltime#"
+
+  [[ atm_monthly_180x360_aave_mvm ]]
+  climo_diurnal_frequency = "diurnal_8xdaily"
+  climo_diurnal_subsection = "atm_monthly_diurnal_8xdaily_180x360_aave"
+  diff_title = "Difference"
+  ref_name = "#expand case_name#"
+  ref_years = "1985-1988",
+  # Use _1 as reference
+  reference_data_path_climo_diurnal = "#expand user_output#zppy_min_case_e3sm_diags_diurnal_cycle_mvm_1_output/#expand unique_id#/#expand case_name#/post/atm/180x360_aave/clim_diurnal_8xdaily"
+  run_type = "model_vs_model"
+  sets = "diurnal_cycle",
+  short_ref_name = "#expand case_name#"
+  swap_test_ref = False
+  tag = "model_vs_model"

--- a/tests/integration/template_min_case_e3sm_diags_lat_lon_land_mvm_1.cfg
+++ b/tests/integration/template_min_case_e3sm_diags_lat_lon_land_mvm_1.cfg
@@ -1,0 +1,23 @@
+[default]
+case = "#expand case_name#"
+constraint = "#expand constraint#"
+dry_run = "#expand dry_run#"
+environment_commands = "#expand environment_commands#"
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/#expand case_name#
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "#expand user_output#zppy_min_case_e3sm_diags_lat_lon_land_mvm_1_output/#expand unique_id#/v2.LR.historical_0201"
+partition = "#expand partition_short#"
+qos = "#expand qos_short#"
+www = "#expand user_www#zppy_min_case_e3sm_diags_lat_lon_land_mvm_1_www/#expand unique_id#"
+years = "1985:1989:4",
+
+[climo]
+active = True
+walltime = "00:30:00"
+
+  [[ land_monthly_climo ]]
+  frequency = "monthly"
+  input_files = "elm.h0"
+  input_subdir = "archive/lnd/hist"
+  vars = ""

--- a/tests/integration/template_min_case_e3sm_diags_lat_lon_land_mvm_2.cfg
+++ b/tests/integration/template_min_case_e3sm_diags_lat_lon_land_mvm_2.cfg
@@ -1,0 +1,49 @@
+[default]
+case = "#expand case_name#"
+constraint = "#expand constraint#"
+dry_run = "#expand dry_run#"
+environment_commands = "#expand environment_commands#"
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/#expand case_name#
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "#expand user_output#zppy_min_case_e3sm_diags_lat_lon_land_mvm_2_output/#expand unique_id#/v2.LR.historical_0201"
+partition = "#expand partition_short#"
+qos = "#expand qos_short#"
+www = "#expand user_www#zppy_min_case_e3sm_diags_lat_lon_land_mvm_2_www/#expand unique_id#"
+years = "1995:1999:4",
+
+[climo]
+active = True
+walltime = "00:30:00"
+
+  [[ land_monthly_climo ]]
+  frequency = "monthly"
+  input_files = "elm.h0"
+  input_subdir = "archive/lnd/hist"
+  vars = ""
+
+[e3sm_diags]
+active = True
+grid = '180x360_aave'
+multiprocessing = True
+num_workers = 8
+partition = "#expand partition_long#"
+qos = "#expand qos_long#"
+short_name = "#expand case_name#"
+walltime = "#expand diags_walltime#"
+
+  [[ lnd_monthly_mvm_lnd ]]
+  climo_subsection = "land_monthly_climo"
+  diff_title = "Difference"
+  ref_final_yr = 1988
+  ref_name = "#expand case_name#"
+  ref_start_yr = 1985
+  ref_years = "1985-1988",
+  # Use _1 as reference
+  reference_data_path = "#expand user_output#zppy_min_case_e3sm_diags_lat_lon_land_mvm_1_output/#expand unique_id#/#expand case_name#/post/lnd/180x360_aave/clim"
+  run_type = "model_vs_model"
+  sets = "lat_lon_land",
+  short_ref_name = "#expand case_name#"
+  swap_test_ref = False
+  tag = "model_vs_model"
+  ts_num_years_ref = 4

--- a/tests/integration/template_min_case_e3sm_diags_streamflow.cfg
+++ b/tests/integration/template_min_case_e3sm_diags_streamflow.cfg
@@ -1,0 +1,41 @@
+[default]
+case = "#expand case_name#"
+constraint = "#expand constraint#"
+dry_run = "#expand dry_run#"
+environment_commands = "#expand environment_commands#"
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/#expand case_name#
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "#expand user_output#zppy_min_case_e3sm_diags_streamflow_output/#expand unique_id#/v2.LR.historical_0201"
+partition = "#expand partition_short#"
+qos = "#expand qos_short#"
+www = "#expand user_www#zppy_min_case_e3sm_diags_streamflow_www/#expand unique_id#"
+years = "1985:1989:4",
+
+[ts]
+active = True
+e3sm_to_cmip_environment_commands = "#expand e3sm_to_cmip_environment_commands#"
+walltime = "00:30:00"
+
+  [[ rof_monthly ]]
+  extra_vars = 'areatotal2'
+  frequency = "monthly"
+  input_files = "mosart.h0"
+  input_subdir = "archive/rof/hist"
+  mapping_file = ""
+  vars = "RIVER_DISCHARGE_OVER_LAND_LIQ"
+
+[e3sm_diags]
+active = True
+grid = '180x360_aave'
+multiprocessing = True
+num_workers = 8
+partition = "#expand partition_long#"
+qos = "#expand qos_long#"
+short_name = "#expand case_name#"
+ts_num_years = 4
+walltime = "#expand diags_walltime#"
+
+  [[ atm_monthly_180x360_aave ]]
+  sets = "streamflow",
+  # streamflow_obs_ts is determined automatically

--- a/tests/integration/template_min_case_e3sm_diags_streamflow_mvm_1.cfg
+++ b/tests/integration/template_min_case_e3sm_diags_streamflow_mvm_1.cfg
@@ -1,0 +1,26 @@
+[default]
+case = "#expand case_name#"
+constraint = "#expand constraint#"
+dry_run = "#expand dry_run#"
+environment_commands = "#expand environment_commands#"
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/#expand case_name#
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "#expand user_output#zppy_min_case_e3sm_diags_streamflow_mvm_1_output/#expand unique_id#/v2.LR.historical_0201"
+partition = "#expand partition_short#"
+qos = "#expand qos_short#"
+www = "#expand user_www#zppy_min_case_e3sm_diags_streamflow_mvm_1_www/#expand unique_id#"
+years = "1985:1989:4",
+
+[ts]
+active = True
+e3sm_to_cmip_environment_commands = "#expand e3sm_to_cmip_environment_commands#"
+walltime = "00:30:00"
+
+  [[ rof_monthly ]]
+  extra_vars = 'areatotal2'
+  frequency = "monthly"
+  input_files = "mosart.h0"
+  input_subdir = "archive/rof/hist"
+  mapping_file = ""
+  vars = "RIVER_DISCHARGE_OVER_LAND_LIQ"

--- a/tests/integration/template_min_case_e3sm_diags_streamflow_mvm_2.cfg
+++ b/tests/integration/template_min_case_e3sm_diags_streamflow_mvm_2.cfg
@@ -1,0 +1,55 @@
+[default]
+case = "#expand case_name#"
+constraint = "#expand constraint#"
+dry_run = "#expand dry_run#"
+environment_commands = "#expand environment_commands#"
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/#expand case_name#
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "#expand user_output#zppy_min_case_e3sm_diags_streamflow_mvm_2_output/#expand unique_id#/v2.LR.historical_0201"
+partition = "#expand partition_short#"
+qos = "#expand qos_short#"
+www = "#expand user_www#zppy_min_case_e3sm_diags_streamflow_mvm_2_www/#expand unique_id#"
+years = "1995:1999:4",
+
+[ts]
+active = True
+e3sm_to_cmip_environment_commands = "#expand e3sm_to_cmip_environment_commands#"
+walltime = "00:30:00"
+
+  [[ rof_monthly ]]
+  extra_vars = 'areatotal2'
+  frequency = "monthly"
+  input_files = "mosart.h0"
+  input_subdir = "archive/rof/hist"
+  mapping_file = ""
+  vars = "RIVER_DISCHARGE_OVER_LAND_LIQ"
+
+[e3sm_diags]
+active = True
+grid = '180x360_aave'
+multiprocessing = True
+num_workers = 8
+partition = "#expand partition_long#"
+qos = "#expand qos_long#"
+short_name = "#expand case_name#"
+ts_num_years = 4
+walltime = "#expand diags_walltime#"
+
+  [[ atm_monthly_180x360_aave_mvm ]]
+  # Test model-vs-model using the same files as the reference
+  diff_title = "Difference"
+  ref_final_yr = 1988
+  ref_name = "#expand_case_name#"
+  ref_start_yr = 1985
+  ref_years = "1985-1988",
+  # Use _1 as reference
+  reference_data_path = "#expand user_output#zppy_min_case_e3sm_diags_streamflow_mvm_1_output/#expand unique_id#/#expand case_name#/post/atm/180x360_aave/clim"
+  # reference_data_path_ts_rof determined automatically
+  run_type = "model_vs_model"
+  sets="streamflow"
+  short_ref_name = "#expand_case_name#"
+  swap_test_ref = False
+  tag = "model_vs_model"
+  ts_num_years_ref = 4
+  years = "1995-1998",

--- a/tests/integration/template_min_case_e3sm_diags_tc_analysis.cfg
+++ b/tests/integration/template_min_case_e3sm_diags_tc_analysis.cfg
@@ -1,0 +1,34 @@
+[default]
+case = "#expand case_name#"
+constraint = "#expand constraint#"
+dry_run = "#expand dry_run#"
+environment_commands = "#expand environment_commands#"
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/#expand case_name#
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "#expand user_output#zppy_min_case_e3sm_diags_tc_analysis_output/#expand unique_id#/v2.LR.historical_0201"
+partition = "#expand partition_short#"
+qos = "#expand qos_short#"
+www = "#expand user_www#zppy_min_case_e3sm_diags_tc_analysis_www/#expand unique_id#"
+years = "1985:1987:2",
+
+[tc_analysis]
+active = True
+scratch = "#expand scratch#"
+walltime = "00:30:00"
+
+[e3sm_diags]
+active = True
+grid = '180x360_aave'
+multiprocessing = True
+num_workers = 8
+partition = "#expand partition_long#"
+qos = "#expand qos_long#"
+short_name = "#expand case_name#"
+ts_num_years = 2
+walltime = "#expand diags_walltime#"
+
+  [[ atm_monthly_180x360_aave_tc_analysis ]]
+  # Note: tc_analysis requires e3sm_diags jobs to run sequentially
+  sets = "tc_analysis",
+  # tc_obs is determined automatically

--- a/tests/integration/template_min_case_e3sm_diags_tc_analysis_mvm_1.cfg
+++ b/tests/integration/template_min_case_e3sm_diags_tc_analysis_mvm_1.cfg
@@ -1,0 +1,18 @@
+[default]
+case = "#expand case_name#"
+constraint = "#expand constraint#"
+dry_run = "#expand dry_run#"
+environment_commands = "#expand environment_commands#"
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/#expand case_name#
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "#expand user_output#zppy_min_case_e3sm_diags_tc_analysis_mvm_1_output/#expand unique_id#/v2.LR.historical_0201"
+partition = "#expand partition_short#"
+qos = "#expand qos_short#"
+www = "#expand user_www#zppy_min_case_e3sm_diags_tc_analysis_mvm_2_www/#expand unique_id#"
+years = "1985:1987:2",
+
+[tc_analysis]
+active = True
+scratch = "#expand scratch#"
+walltime = "00:30:00"

--- a/tests/integration/template_min_case_e3sm_diags_tc_analysis_mvm_2.cfg
+++ b/tests/integration/template_min_case_e3sm_diags_tc_analysis_mvm_2.cfg
@@ -1,0 +1,46 @@
+[default]
+case = "#expand case_name#"
+constraint = "#expand constraint#"
+dry_run = "#expand dry_run#"
+environment_commands = "#expand environment_commands#"
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/#expand case_name#
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "#expand user_output#zppy_min_case_e3sm_diags_tc_analysis_mvm_2_output/#expand unique_id#/v2.LR.historical_0201"
+partition = "#expand partition_short#"
+qos = "#expand qos_short#"
+www = "#expand user_www#zppy_min_case_e3sm_diags_tc_analysis_mvm_2_www/#expand unique_id#"
+years = "1995:1997:2",
+
+[tc_analysis]
+active = True
+scratch = "#expand scratch#"
+walltime = "00:30:00"
+
+[e3sm_diags]
+active = True
+grid = '180x360_aave'
+multiprocessing = True
+num_workers = 8
+partition = "#expand partition_long#"
+qos = "#expand qos_long#"
+short_name = "#expand case_name#"
+walltime = "#expand diags_walltime#"
+
+    [[ atm_monthly_180x360_aave_mvm ]]
+  # Test model-vs-model using the same files as the reference
+  climo_subsection = "atm_monthly_180x360_aave"
+  diff_title = "Difference"
+  ref_final_yr = 1986
+  ref_name = "#expand case_name#"
+  ref_start_yr = 1985
+  ref_years = "1985-1986",
+  # Use _1 as reference
+  reference_data_path = "#expand user_output#zppy_min_case_e3sm_diags_tc_analysis_mvm_1_output/#expand unique_id#/#expand case_name#/post/atm/180x360_aave/clim"
+  # reference_data_path_tc determined automatically
+  run_type = "model_vs_model"
+  sets = "tc_analysis",
+  short_ref_name = "#expand case_name#"
+  swap_test_ref = False
+  tag = "model_vs_model"
+  years = "1995-1996",

--- a/tests/integration/template_min_case_e3sm_diags_tropical_subseasonal.cfg
+++ b/tests/integration/template_min_case_e3sm_diags_tropical_subseasonal.cfg
@@ -1,0 +1,38 @@
+[default]
+case = "#expand case_name#"
+constraint = "#expand constraint#"
+dry_run = "#expand dry_run#"
+environment_commands = "#expand environment_commands#"
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/#expand case_name#
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "#expand user_output#zppy_min_case_e3sm_diags_tropical_subseasonal_output/#expand unique_id#/v2.LR.historical_0201"
+partition = "#expand partition_short#"
+qos = "#expand qos_short#"
+www = "#expand user_www#zppy_min_case_e3sm_diags_tropical_subseasonal_www/#expand unique_id#"
+years = "1985:1989:4",
+
+[ts]
+active = True
+e3sm_to_cmip_environment_commands = "#expand e3sm_to_cmip_environment_commands#"
+walltime = "00:30:00"
+
+  [[ atm_daily_180x360_aave ]]
+  frequency = "daily"
+  input_files = "eam.h1"
+  input_subdir = "archive/atm/hist"
+  vars = "PRECT"
+
+[e3sm_diags]
+active = True
+grid = '180x360_aave'
+multiprocessing = True
+num_workers = 8
+partition = "#expand partition_long#"
+qos = "#expand qos_long#"
+short_name = "#expand case_name#"
+ts_num_years = 4
+walltime = "#expand diags_walltime#"
+
+  [[ atm_monthly_180x360_aave ]]
+  sets = "tropical_subseasonal",

--- a/tests/integration/template_min_case_e3sm_diags_tropical_subseasonal_mvm_1.cfg
+++ b/tests/integration/template_min_case_e3sm_diags_tropical_subseasonal_mvm_1.cfg
@@ -1,0 +1,24 @@
+[default]
+case = "#expand case_name#"
+constraint = "#expand constraint#"
+dry_run = "#expand dry_run#"
+environment_commands = "#expand environment_commands#"
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/#expand case_name#
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "#expand user_output#zppy_min_case_e3sm_diags_tropical_subseasonal_mvm_1_output/#expand unique_id#/v2.LR.historical_0201"
+partition = "#expand partition_short#"
+qos = "#expand qos_short#"
+www = "#expand user_www#zppy_min_case_e3sm_diags_tropical_subseasonal_mvm_1_www/#expand unique_id#"
+years = "1985:1989:4",
+
+[ts]
+active = True
+e3sm_to_cmip_environment_commands = "#expand e3sm_to_cmip_environment_commands#"
+walltime = "00:30:00"
+
+  [[ atm_daily_180x360_aave ]]
+  frequency = "daily"
+  input_files = "eam.h1"
+  input_subdir = "archive/atm/hist"
+  vars = "PRECT"

--- a/tests/integration/template_min_case_e3sm_diags_tropical_subseasonal_mvm_2.cfg
+++ b/tests/integration/template_min_case_e3sm_diags_tropical_subseasonal_mvm_2.cfg
@@ -1,0 +1,55 @@
+[default]
+case = "#expand case_name#"
+constraint = "#expand constraint#"
+dry_run = "#expand dry_run#"
+environment_commands = "#expand environment_commands#"
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/#expand case_name#
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "#expand user_output#zppy_min_case_e3sm_diags_tropical_subseasonal_mvm_2_output/#expand unique_id#/v2.LR.historical_0201"
+partition = "#expand partition_short#"
+qos = "#expand qos_short#"
+www = "#expand user_www#zppy_min_case_e3sm_diags_tropical_subseasonal_mvm_2_www/#expand unique_id#"
+years = "1995:1999:4",
+
+[ts]
+active = True
+e3sm_to_cmip_environment_commands = "#expand e3sm_to_cmip_environment_commands#"
+walltime = "00:30:00"
+
+  [[ atm_daily_180x360_aave ]]
+  frequency = "daily"
+  input_files = "eam.h1"
+  input_subdir = "archive/atm/hist"
+  vars = "PRECT"
+
+[e3sm_diags]
+active = True
+grid = '180x360_aave'
+multiprocessing = True
+num_workers = 8
+partition = "#expand partition_long#"
+qos = "#expand qos_long#"
+short_name = "#expand case_name#"
+ts_num_years = 4
+walltime = "#expand diags_walltime#"
+
+  [[ atm_monthly_180x360_aave_mvm ]]
+  # Test model-vs-model using the same files as the reference
+  climo_subsection = "atm_monthly_180x360_aave"
+  diff_title = "Difference"
+  ref_final_yr = 1988
+  ref_name = "#expand case_name#"
+  ref_start_yr = 1985
+  ref_years = "1985-1988",
+  # Use _1 as reference
+  reference_data_path = "#expand user_output#zppy_min_case_e3sm_diags_tropical_subseasonal_mvm_1_output/#expand unique_id#/#expand case_name#/post/atm/180x360_aave/clim"
+  # reference_data_path_daily is determined automatically
+  run_type = "model_vs_model"
+  sets = "tropical_subseasonal",
+  short_ref_name = "#expand case_name#"
+  swap_test_ref = False
+  tag = "model_vs_model"
+  ts_num_years_ref = 4
+  ts_subsection = "atm_monthly_180x360_aave"
+  years = "1995-1998",

--- a/tests/integration/template_min_case_global_time_series_custom.cfg
+++ b/tests/integration/template_min_case_global_time_series_custom.cfg
@@ -1,0 +1,44 @@
+[default]
+case = "#expand case_name#"
+constraint = "#expand constraint#"
+dry_run = "#expand dry_run#"
+environment_commands = "#expand environment_commands#"
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/#expand case_name#
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "#expand user_output#zppy_min_case_global_time_series_custom_output/#expand unique_id#/v2.LR.historical_0201"
+partition = "#expand partition_short#"
+qos = "#expand qos_short#"
+www = "#expand user_www#zppy_min_case_global_time_series_custom_www/#expand unique_id#"
+
+[ts]
+active = True
+e3sm_to_cmip_environment_commands = "#expand e3sm_to_cmip_environment_commands#"
+walltime = "00:30:00"
+years = "1985:1995:5",
+
+  [[ atm_monthly_glb ]]
+  # Note global average won't work for 3D variables.
+  frequency = "monthly"
+  input_files = "eam.h0"
+  input_subdir = "archive/atm/hist"
+  mapping_file = "glb"
+  vars = "TREFHT,AODDUST"
+
+  [[ lnd_monthly_glb ]]
+  frequency = "monthly"
+  input_files = "elm.h0"
+  input_subdir = "archive/lnd/hist"
+  mapping_file = "glb"
+  vars = "FSH,RH2M,LAISHA,LAISUN,QINTR,QOVER,QRUNOFF,QSOIL,QVEGE,QVEGT,SOILWATER_10CM,TSA,H2OSNO,TOTLITC,CWDC,SOIL1C,SOIL2C,SOIL3C,SOIL4C,WOOD_HARVESTC,TOTVEGC,NBP,GPP,AR,HR"
+
+[global_time_series]
+active = True
+experiment_name = "#expand case_name#"
+figstr = "#expand case_name#"
+plots_original=""
+plots_atm = "TREFHT,AODDUST"
+plots_lnd = "FSH,RH2M,LAISHA,LAISUN,QINTR,QOVER,QRUNOFF,QSOIL,QVEGE,QVEGT,SOILWATER_10CM,TSA,H2OSNO,TOTLITC,CWDC,SOIL1C,SOIL2C,SOIL3C,SOIL4C,WOOD_HARVESTC,TOTVEGC,NBP,GPP,AR,HR"
+ts_num_years = 5
+walltime = "00:30:00"
+years = "1985-1995",

--- a/tests/integration/template_min_case_global_time_series_original_8.cfg
+++ b/tests/integration/template_min_case_global_time_series_original_8.cfg
@@ -1,0 +1,49 @@
+[default]
+case = "#expand case_name#"
+constraint = "#expand constraint#"
+dry_run = "#expand dry_run#"
+environment_commands = "#expand environment_commands#"
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/#expand case_name#
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "#expand user_output#zppy_min_case_global_time_series_original_8_output/#expand unique_id#/v2.LR.historical_0201"
+partition = "#expand partition_short#"
+qos = "#expand qos_short#"
+www = "#expand user_www#zppy_min_case_global_time_series_original_8_www/#expand unique_id#"
+
+[ts]
+active = True
+e3sm_to_cmip_environment_commands = "#expand e3sm_to_cmip_environment_commands#"
+walltime = "00:30:00"
+
+  [[ atm_monthly_glb ]]
+  # Note global average won't work for 3D variables.
+  frequency = "monthly"
+  input_files = "eam.h0"
+  input_subdir = "archive/atm/hist"
+  mapping_file = "glb"
+  years = "1985:1995:5",
+
+[mpas_analysis]
+active = True
+anomalyRefYear = 1985
+climo_years = "1985-1989", "1990-1995",
+enso_years = "1985-1989", "1990-1995",
+mesh = "IcoswISC30E3r5"
+parallelTaskCount = 6
+partition = "#expand partition_long#"
+qos = "#expand qos_long#"
+shortTermArchive = True
+ts_years = "1985-1989", "1985-1995",
+walltime = "#expand mpas_analysis_walltime#"
+
+[global_time_series]
+active = True
+climo_years = "1985-1989", "1990-1995",
+experiment_name = "#expand case_name#"
+figstr = "#expand case_name#"
+moc_file=mocTimeSeries_1985-1995.nc
+ts_num_years = 5
+ts_years = "1985-1989", "1985-1995",
+walltime = "00:30:00"
+years = "1985-1995",

--- a/tests/integration/template_min_case_global_time_series_original_8_no_ocn.cfg
+++ b/tests/integration/template_min_case_global_time_series_original_8_no_ocn.cfg
@@ -1,0 +1,34 @@
+[default]
+case = "#expand case_name#"
+constraint = "#expand constraint#"
+dry_run = "#expand dry_run#"
+environment_commands = "#expand environment_commands#"
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/#expand case_name#
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "#expand user_output#zppy_min_case_global_time_series_original_8_no_ocn_output/#expand unique_id#/v2.LR.historical_0201"
+partition = "#expand partition_short#"
+qos = "#expand qos_short#"
+www = "#expand user_www#zppy_min_case_global_time_series_original_8_no_ocn_www/#expand unique_id#"
+
+[ts]
+active = True
+e3sm_to_cmip_environment_commands = "#expand e3sm_to_cmip_environment_commands#"
+walltime = "00:30:00"
+
+  [[ atm_monthly_glb ]]
+  # Note global average won't work for 3D variables.
+  frequency = "monthly"
+  input_files = "eam.h0"
+  input_subdir = "archive/atm/hist"
+  mapping_file = "glb"
+  years = "1985:1995:5",
+
+[global_time_series]
+active = True
+experiment_name = "#expand case_name#"
+figstr = "#expand case_name#"
+plots_original="net_toa_flux_restom,global_surface_air_temperature,toa_radiation,net_atm_energy_imbalance,change_ohc,max_moc,change_sea_level,net_atm_water_imbalance"
+ts_num_years = 5
+walltime = "00:30:00"
+years = "1985-1995",

--- a/tests/integration/template_min_case_ilamb.cfg
+++ b/tests/integration/template_min_case_ilamb.cfg
@@ -1,0 +1,42 @@
+[default]
+case = "#expand case_name#"
+constraint = "#expand constraint#"
+dry_run = "#expand dry_run#"
+environment_commands = "#expand environment_commands#"
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/#expand case_name#
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "#expand user_output#zppy_min_case_ilamb_output/#expand unique_id#/v2.LR.historical_0201"
+partition = "#expand partition_short#"
+qos = "#expand qos_short#"
+www = "#expand user_www#zppy_min_case_ilamb_www/#expand unique_id#"
+
+[ts]
+active = True
+e3sm_to_cmip_environment_commands = "#expand e3sm_to_cmip_environment_commands#"
+walltime = "00:50:00"
+ts_fmt = "cmip"
+years = "1985:2014:30"
+
+  [[ atm_monthly_180x360_aave ]]
+  frequency = "monthly"
+  input_files = "eam.h0"
+  input_subdir = "archive/atm/hist"
+  vars = "FSNTOA,FLUT,FSNT,FLNT,FSNS,FLNS,SHFLX,QFLX,TAUX,TAUY,PRECC,PRECL,PRECSC,PRECSL,TS,TREFHT,CLDTOT,CLDHGH,CLDMED,CLDLOW,U,ICEFRAC,LANDFRAC,OCNFRAC,PS,CLDICE,CLDLIQ,T,AODDUST"
+
+  [[ land_monthly ]]
+  extra_vars = "landfrac"
+  frequency = "monthly"
+  input_files = "elm.h0"
+  input_subdir = "archive/lnd/hist"
+  mapping_file = "map_r05_to_cmip6_180x360_aave.20231110.nc"
+  vars = "FSH,RH2M,LAISHA,LAISUN,QINTR,QOVER,QRUNOFF,QSOIL,QVEGE,QVEGT,SOILICE,SOILLIQ,SOILWATER_10CM,TSA,TSOI,H2OSNO,TOTLITC,CWDC,SOIL1C,SOIL2C,SOIL3C,SOIL4C,WOOD_HARVESTC,TOTVEGC,NBP,GPP,AR,HR"
+
+[ilamb]
+active = True
+nodes = 8
+partition = "#expand partition_long#"
+short_name = "#expand case_name#"
+ts_num_years = 30
+walltime = "2:00:00"
+years = "1985:2014:30"

--- a/tests/integration/template_min_case_ilamb_land_only.cfg
+++ b/tests/integration/template_min_case_ilamb_land_only.cfg
@@ -1,0 +1,37 @@
+[default]
+case = "#expand case_name#"
+constraint = "#expand constraint#"
+dry_run = "#expand dry_run#"
+environment_commands = "#expand environment_commands#"
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/#expand case_name#
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "#expand user_output#zppy_min_case_ilamb_land_only_output/#expand unique_id#/v2.LR.historical_0201"
+partition = "#expand partition_short#"
+qos = "#expand qos_short#"
+www = "#expand user_www#zppy_min_case_ilamb_land_only_www/#expand unique_id#"
+
+[ts]
+active = True
+e3sm_to_cmip_environment_commands = "#expand e3sm_to_cmip_environment_commands#"
+walltime = "00:50:00"
+ts_fmt = "cmip"
+years = "1985:2014:30"
+
+  [[ land_monthly ]]
+  extra_vars = "landfrac"
+  frequency = "monthly"
+  input_files = "elm.h0"
+  input_subdir = "archive/lnd/hist"
+  mapping_file = "map_r05_to_cmip6_180x360_aave.20231110.nc"
+  vars = "FSH,RH2M,LAISHA,LAISUN,QINTR,QOVER,QRUNOFF,QSOIL,QVEGE,QVEGT,SOILICE,SOILLIQ,SOILWATER_10CM,TSA,TSOI,H2OSNO,TOTLITC,CWDC,SOIL1C,SOIL2C,SOIL3C,SOIL4C,WOOD_HARVESTC,TOTVEGC,NBP,GPP,AR,HR"
+
+[ilamb]
+active = True
+land_only = True
+nodes = 8
+partition = "#expand partition_long#"
+short_name = "#expand case_name#"
+ts_num_years = 30
+walltime = "2:00:00"
+years = "1985:2014:30"

--- a/tests/integration/template_min_case_mpas_analysis.cfg
+++ b/tests/integration/template_min_case_mpas_analysis.cfg
@@ -1,0 +1,25 @@
+[default]
+case = "#expand case_name#"
+constraint = "#expand constraint#"
+dry_run = "#expand dry_run#"
+environment_commands = "#expand environment_commands#"
+input = /lcrc/group/e3sm2/ac.wlin/E3SMv3/#expand case_name#
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "#expand user_output#zppy_min_case_mpas_analysis_output/#expand unique_id#/v2.LR.historical_0201"
+partition = "#expand partition_short#"
+qos = "#expand qos_short#"
+www = "#expand user_www#zppy_min_case_mpas_analysis_www/#expand unique_id#"
+
+[mpas_analysis]
+active = True
+anomalyRefYear = 1985
+climo_years = "1985-1989", "1990-1995",
+enso_years = "1985-1989", "1990-1995",
+mesh = "IcoswISC30E3r5"
+parallelTaskCount = 6
+partition = "#expand partition_long#"
+qos = "#expand qos_long#"
+shortTermArchive = True
+ts_years = "1985-1989", "1985-1995",
+walltime = "#expand mpas_analysis_walltime#"

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -134,6 +134,7 @@ def get_chyrsalis_expansions(config):
     web_base_path = config.get("web_portal", "base_path")
     d = {
         "bundles_walltime": "07:00:00",
+        "case_name": "v3.LR.historical_0051",
         "constraint": "",
         # To run this test, replace conda environment with your e3sm_diags dev environment
         "diags_environment_commands": "source /home/ac.forsyth2/miniconda3/etc/profile.d/conda.sh; conda activate e3sm_diags_20240610",
@@ -160,6 +161,7 @@ def get_compy_expansions(config):
     web_base_path = config.get("web_portal", "base_path")
     d = {
         "bundles_walltime": "02:00:00",
+        "case_name": "v3.LR.historical_0051",
         "constraint": "",
         # To run this test, replace conda environment with your e3sm_diags dev environment
         "diags_environment_commands": "source /qfs/people/fors729/mambaforge/etc/profile.d/conda.sh; conda activate e3sm_diags_20240328",
@@ -186,6 +188,7 @@ def get_perlmutter_expansions(config):
     web_base_path = config.get("web_portal", "base_path")
     d = {
         "bundles_walltime": "6:00:00",
+        "case_name": "v3.LR.historical_0051",
         "constraint": "cpu",
         # To run this test, replace conda environment with your e3sm_diags dev environment
         "diags_environment_commands": "source /global/homes/f/forsyth/miniconda3/etc/profile.d/conda.sh; conda activate e3sm_diags_20240429",
@@ -260,7 +263,38 @@ def generate_cfgs(unified_testing=False, dry_run=False):
     else:
         expansions["dry_run"] = "False"
 
-    cfg_names = ["bundles", "complete_run", "debug"]
+    cfg_names = [
+        "bundles",
+        "complete_run",
+        "debug",
+        "min_case_e3sm_diags_depend_on_climo_mvm_1",
+        "min_case_e3sm_diags_depend_on_climo_mvm_2",
+        "min_case_e3sm_diags_depend_on_climo",
+        "min_case_e3sm_diags_depend_on_ts_mvm_1",
+        "min_case_e3sm_diags_depend_on_ts_mvm_2",
+        "min_case_e3sm_diags_depend_on_ts",
+        "min_case_e3sm_diags_diurnal_cycle_mvm_1",
+        "min_case_e3sm_diags_diurnal_cycle_mvm_2",
+        "min_case_e3sm_diags_diurnal_cycle",
+        "min_case_e3sm_diags_lat_lon_land_mvm_1",
+        "min_case_e3sm_diags_lat_lon_land_mvm_2",
+        # "min_case_e3sm_diags_lat_lon_land",
+        "min_case_e3sm_diags_streamflow_mvm_1",
+        "min_case_e3sm_diags_streamflow_mvm_2",
+        "min_case_e3sm_diags_streamflow",
+        "min_case_e3sm_diags_tc_analysis_mvm_1",
+        "min_case_e3sm_diags_tc_analysis_mvm_2",
+        "min_case_e3sm_diags_tc_analysis",
+        "min_case_e3sm_diags_tropical_subseasonal_mvm_1",
+        "min_case_e3sm_diags_tropical_subseasonal_mvm_2",
+        "min_case_e3sm_diags_tropical_subseasonal",
+        "min_case_global_time_series_custom",
+        "min_case_global_time_series_original_8_no_ocn",
+        "min_case_global_time_series_original_8",
+        "min_case_ilamb_land_only",
+        "min_case_ilamb",
+        "min_case_mpas_analysis",
+    ]
     for cfg_name in cfg_names:
         cfg_template = f"{git_top_level}/tests/integration/template_{cfg_name}.cfg"
         cfg_generated = (


### PR DESCRIPTION
Add minimal case cfgs. Addresses 'Automated testing of the "combinatorial explosion" of parameter options. Often we need to know how `zppy` behaves when different combination of parameters are applied. Setting up automatic `cfg` generation and testing of these cases would be immensely helpful.' in #572.

This pull request aims to add some important "minimal cases" -- i.e., cfgs with as few parameters as possible to test specific cases.