### PR TITLE
Update supported python versions

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -18,10 +18,10 @@ build:
 
 requirements:
   host:
-    - python >=3.6
+    - python >=3.9
     - pip
   run:
-    - python >=3.6
+    - python >=3.9
     - configobj >=5.0.0,<6.0.0
     - jinja2 >=2.0.0
     - mache >=1.3.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ exclude =
     venv
 
 [mypy]
-python_version = 3.7
+python_version = 3.9
 check_untyped_defs = True
 ignore_missing_imports = True
 warn_unused_ignores = True


### PR DESCRIPTION
Support for Python 3.8 (and lower) has been dropped from `conda-forge`, so I've updated the lower bounds of supported versions here accordingly.

---
Updated template from @forsyth2 

## Issue resolution
- Equivalent to https://github.com/E3SM-Project/e3sm_diags/pull/844, https://github.com/E3SM-Project/zstash/pull/351

This pull request is a minor adjustment that would increment the patch version.

## 1. Does this do what we want it to do?

Objectives:
- Make Python 3.9 the oldest supported Python version in `zppy`.

Required:
- [x] Product Management: I have confirmed with the stakeholders that the objectives above are correct and complete.
- [ ] Testing: I have added or modified at least one "min-case" configuration file to test this change. Every objective above is represented in at least one cfg.
  - Existing tests are run in an environment already using Python 3.9.
- [x] Testing: I have considered likely and/or severe edge cases and have included them in testing.

## 2. Are the implementation details accurate & efficient?

Required:
- [x] Logic: I have visually inspected the entire pull request myself.

## 3. Is this well documented?

Required:
- [ ] Documentation: by looking at the docs, a new user could easily understand the functionality introduced by this pull request.
  - This change does not require new documentation.

## 4. Is this code clean?

Required:
- [x] Readability: The code is as simple as possible and well-commented, such that a new team member could understand what's happening.
- [x] Pre-commit checks: All the pre-commits checks have passed.