### PR TITLE
Fix dir issues in comparing images

### DIFF
--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -62,13 +62,23 @@ def compare_images(
 
             mismatched_images.append(image_name)
 
+            diff_dir_actual_png = os.path.join(
+                diff_dir, "{}_actual.png".format(image_name)
+            )
+            # image_name could contain a number of subdirectories.
+            os.makedirs(os.path.dirname(diff_dir_actual_png), exist_ok=True)
             shutil.copy(
                 path_to_actual_png,
-                os.path.join(diff_dir, "{}_actual.png".format(image_name)),
+                diff_dir_actual_png,
             )
+            diff_dir_expected_png = os.path.join(
+                diff_dir, "{}_expected.png".format(image_name)
+            )
+            # image_name could contain a number of subdirectories.
+            os.makedirs(os.path.dirname(diff_dir_expected_png), exist_ok=True)
             shutil.copy(
                 path_to_expected_png,
-                os.path.join(diff_dir, "{}_expected.png".format(image_name)),
+                diff_dir_expected_png,
             )
             # https://stackoverflow.com/questions/41405632/draw-a-rectangle-and-a-text-in-it-using-pil
             draw = ImageDraw.Draw(diff)


### PR DESCRIPTION
## Issue resolution
- Closes #635

Select one: This pull request is...
- [x] a bug fix: increment the patch version
- [ ] a small improvement: increment the minor version
- [ ] an incompatible (non-backwards compatible) API change: increment the major version

## 1. Does this do what we want it to do?

Objectives:
- Fix bug in integration testing where `image_check_failures` directories weren't generating properly.
- The other issues of #635 will be resolved elsewhere:
  - Per https://github.com/E3SM-Project/zppy/issues/635#issuecomment-2442506519, the `lnd` issue will be resolved by #633.
  - The image check failures that show up are consistent with the changes from https://github.com/E3SM-Project/e3sm_diags/pull/851. We can update the expected results accordingly, but I'm hesitant to do that until we get #633 merged to correct the `lnd` issue. So, I will do that after #633 merges.

Required:
- [x] Product Management: I have confirmed with the stakeholders that the objectives above are correct and complete.
- [ ] Testing: I have added or modified at least one "min-case" configuration file to test this change. Every objective above is represented in at least one cfg.
 - This is specifically part of weekly testing.
- [x] Testing: I have considered likely and/or severe edge cases and have included them in testing.


## 2. Are the implementation details accurate & efficient?

Required:
- [x] Logic: I have visually inspected the entire pull request myself.
- [ ] Logic: I have left GitHub comments highlighting important pieces of code logic. I have had these code blocks reviewed by at least one other team member.

## 3. Is this well documented?

Required:
- [ ] Documentation: by looking at the docs, a new user could easily understand the functionality introduced by this pull request.
 - This is non-user facing.

## 4. Is this code clean?

Required:
- [x] Readability: The code is as simple as possible and well-commented, such that a new team member could understand what's happening.
- [x] Pre-commit checks: All the pre-commits checks have passed.
