### PR TITLE
Enable CDAT-migrated E3SM Diags

### DIFF
--- a/zppy/templates/e3sm_diags.bash
+++ b/zppy/templates/e3sm_diags.bash
@@ -67,48 +67,6 @@ create_links_climo_diurnal()
   cd ..
 }
 
-create_links_ts()
-{
-  ts_dir_source=$1
-  ts_dir_destination=$2
-  begin_year=$3
-  end_year=$4
-  error_num=$5
-  # Create xml files for time series variables
-  mkdir -p ${ts_dir_destination}
-  cd ${ts_dir_destination}
-  # https://stackoverflow.com/questions/27702452/loop-through-a-comma-separated-shell-variable
-  variables="{{ vars }}"
-  for v in ${variables//,/ }
-  do
-    # Go through the time series files for between year1 and year2, using a step size equal to the number of years per time series file
-    for year in `seq ${begin_year} {{ ts_num_years }} ${end_year}`;
-    do
-      YYYY=`printf "%04d" ${year}`
-      for file in ${ts_dir_source}/${v}_${YYYY}*.nc
-      do
-        cp ${file} ${ts_dir_destination}/${v}_${YYYY}*.nc
-      done
-    done
-  done
-  cd ..
-}
-
-create_links_ts_rof()
-{
-  ts_rof_dir_source=$1
-  ts_rof_dir_destination=$2
-  begin_year=$3
-  end_year=$4
-  error_num=$5
-  mkdir -p ${ts_rof_dir_destination}
-  cd ${ts_rof_dir_destination}
-  v="RIVER_DISCHARGE_OVER_LAND_LIQ"
-  cp ${ts_rof_dir_source}/${v}_*.nc ${v}_*.nc
-  cd ..
-}
-
-
 {%- if ("lat_lon_land" in sets) %}
 {% if run_type == "model_vs_obs" %}
 climo_dir_primary_land=climo_land
@@ -162,18 +120,10 @@ create_links_climo_diurnal ${climo_diurnal_dir_source} ${climo_diurnal_dir_ref} 
 {%- endif %}
 
 {%- if ("enso_diags" in sets) or ("qbo" in sets) or ("area_mean_time_series" in sets) %}
-{% if run_type == "model_vs_obs" %}
-ts_dir_primary=ts
-{% elif run_type == "model_vs_model" %}
-ts_dir_primary=ts_test
-{%- endif %}
 # Create xml files for time series variables
-ts_dir_source={{ output }}/post/atm/{{ grid }}/ts/monthly/{{ '%dyr' % (ts_num_years) }}
-create_links_ts ${ts_dir_source} ${ts_dir_primary} ${Y1} ${Y2} 5
+ts_dir_primary={{ output }}/post/atm/{{ grid }}/ts/monthly/{{ '%dyr' % (ts_num_years) }}
 {% if run_type == "model_vs_model" %}
-ts_dir_source={{ reference_data_path_ts }}/{{ ts_num_years_ref }}yr
-ts_dir_ref=ts_ref
-create_links_ts ${ts_dir_source} ${ts_dir_ref} ${ref_Y1} ${ref_Y2} 6
+ts_dir_ref={{ reference_data_path_ts }}/{{ ts_num_years_ref }}yr
 {%- endif %}
 {%- endif %}
 
@@ -185,17 +135,9 @@ ts_daily_dir_ref={{ reference_data_path_ts_daily }}/{{ ts_num_years_ref }}yr
 {%- endif %}
 
 {%- if "streamflow" in sets %}
-{% if run_type == "model_vs_obs" %}
-ts_rof_dir_primary=rof
-{% elif run_type == "model_vs_model" %}
-ts_rof_dir_primary=rof_test
-{%- endif %}
-ts_rof_dir_source="{{ output }}/post/rof/native/ts/monthly/{{ ts_num_years }}yr"
-create_links_ts_rof ${ts_rof_dir_source} ${ts_rof_dir_primary} ${Y1} ${Y2} 7
+ts_rof_dir_primary="{{ output }}/post/rof/native/ts/monthly/{{ ts_num_years }}yr"
 {% if run_type == "model_vs_model" %}
-ts_rof_dir_source={{ reference_data_path_ts_rof }}/{{ ts_num_years_ref }}yr
-ts_rof_dir_ref=ts_rof_ref
-create_links_ts_rof ${ts_rof_dir_source} ${ts_rof_dir_ref} ${ref_Y1} ${ref_Y2} 8
+ts_rof_dir_ref={{ reference_data_path_ts_rof }}/{{ ts_num_years_ref }}yr
 {%- endif %}
 {%- endif %}
 

--- a/zppy/templates/e3sm_diags.bash
+++ b/zppy/templates/e3sm_diags.bash
@@ -87,19 +87,9 @@ create_links_ts()
       YYYY=`printf "%04d" ${year}`
       for file in ${ts_dir_source}/${v}_${YYYY}*.nc
       do
-        # Add this time series file to the list of files for cdscan to use
-        echo ${file} >> ${v}_files.txt
+        cp ${file} ${ts_dir_destination}/${v}_${YYYY}*.nc
       done
     done
-    # xml file will cover the whole period from year1 to year2
-    xml_name=${v}_${begin_year}01_${end_year}12.xml
-    export CDMS_NO_MPI=true
-    cdscan -x ${xml_name} -f ${v}_files.txt
-    if [ $? != 0 ]; then
-      cd {{ scriptDir }}
-      echo "ERROR (${error_num})" > {{ prefix }}.status
-      exit ${error_num}
-    fi
   done
   cd ..
 }
@@ -114,13 +104,7 @@ create_links_ts_rof()
   mkdir -p ${ts_rof_dir_destination}
   cd ${ts_rof_dir_destination}
   v="RIVER_DISCHARGE_OVER_LAND_LIQ"
-  xml_name=${v}_${begin_year}01_${end_year}12.xml
-  cdscan -x ${xml_name} ${ts_rof_dir_source}/${v}_*.nc
-  if [ $? != 0 ]; then
-    cd {{ scriptDir }}
-    echo "ERROR (${error_num})" > {{ prefix }}.status
-    exit ${error_num}
-  fi
+  cp ${ts_rof_dir_source}/${v}_*.nc ${v}_*.nc
   cd ..
 }
 


### PR DESCRIPTION
## Issue resolution
- Closes #346. Replaces #598 

Select one: This pull request is...
- [ ] a bug fix: increment the patch version
- [x] a small improvement: increment the minor version
- [ ] an incompatible (non-backwards compatible) API change: increment the major version

## 1. Does this do what we want it to do?

Objectives:
- Enable `zppy` to call the CDAT-migrated E3SM Diags

Required:
- [x] Product Management: I have confirmed with the stakeholders that the objectives above are correct and complete.
- [ ] Testing: I have added or modified at least one "min-case" configuration file to test this change. Every objective above is represented in at least one cfg.
- [ ] Testing: I have considered likely and/or severe edge cases and have included them in testing.

If applicable:
- [ ] Testing: this pull request introduces an important feature or bug fix that we _must_ test often. I have updated the weekly-test configuration files, not just a "min-case" one.
- [ ] Testing: this pull request adds at least one new possible parameter to the cfg. I have tested using this parameter with and without any other parameter that may interact with it.

## 2. Are the implementation details accurate & efficient?

Required:
- [x] Logic: I have visually inspected the entire pull request myself.
- [x] Logic: I have left GitHub comments highlighting important pieces of code logic. I have had these code blocks reviewed by at least one other team member.

If applicable:
- [ ] Dependencies: This pull request introduces a new dependency. I have discussed this requirement with at least one other team member. The dependency is noted in `zppy/conda`, not just an `import` statement.

## 3. Is this well documented?

Required:
- [ ] Documentation: by looking at the docs, a new user could easily understand the functionality introduced by this pull request.

## 4. Is this code clean?

Required:
- [x] Readability: The code is as simple as possible and well-commented, such that a new team member could understand what's happening.
- [x] Pre-commit checks: All the pre-commits checks have passed.

If applicable:
- [x] Software architecture: I have discussed relevant trade-offs in design decisions with at least one other team member. It is unlikely that this pull request will increase tech debt.
