### PR TITLE
Skip `oceanConservation` task in MPAS-Analysis

### DIFF
--- a/zppy/defaults/cryosphere.cfg
+++ b/zppy/defaults/cryosphere.cfg
@@ -2,4 +2,4 @@
 sets= "lat_lon","zonal_mean_xy","zonal_mean_2d","polar","cosp_histogram","meridional_mean_2d","enso_diags","qbo","diurnal_cycle","annual_cycle_zonal_mean","streamflow","zonal_mean_2d_stratosphere","aerosol_aeronet","aerosol_budget"
 
 [mpas_analysis]
-generate = 'all', 'no_BGC', 'no_icebergs', 'no_waves', 'no_eke'
+generate = 'all', 'no_BGC', 'no_icebergs', 'no_waves', 'no_eke', 'no_oceanConservation'

--- a/zppy/defaults/water_cycle.cfg
+++ b/zppy/defaults/water_cycle.cfg
@@ -2,4 +2,4 @@
 sets = "lat_lon","zonal_mean_xy","zonal_mean_2d","polar","cosp_histogram","meridional_mean_2d","enso_diags","qbo","diurnal_cycle","annual_cycle_zonal_mean","streamflow","zonal_mean_2d_stratosphere","aerosol_aeronet","aerosol_budget"
 
 [mpas_analysis]
-generate = 'all', 'no_landIceCavities', 'no_BGC', 'no_icebergs', 'no_min', 'no_max', 'no_sose', 'no_waves', 'no_eke', 'no_climatologyMapAntarcticMelt', 'no_regionalTSDiagrams', 'no_timeSeriesAntarcticMelt', 'no_timeSeriesOceanRegions', 'no_climatologyMapSose', 'no_woceTransects', 'no_soseTransects', 'no_geojsonTransects', 'no_oceanRegionalProfiles', 'no_hovmollerOceanRegions'
+generate = 'all', 'no_landIceCavities', 'no_BGC', 'no_icebergs', 'no_min', 'no_max', 'no_sose', 'no_waves', 'no_eke', 'no_climatologyMapAntarcticMelt', 'no_regionalTSDiagrams', 'no_timeSeriesAntarcticMelt', 'no_timeSeriesOceanRegions', 'no_climatologyMapSose', 'no_woceTransects', 'no_soseTransects', 'no_geojsonTransects', 'no_oceanRegionalProfiles', 'no_hovmollerOceanRegions', 'no_oceanConservation'


### PR DESCRIPTION
The conservation check is turned off in E3SM by default so we don't want to run the analysis by default.  (Doing so would ultimately be harmless but there would be a confusing error message on setup.)

## Issue resolution

Select one: This pull request is...
- [ ] a bug fix: increment the patch version
- [x] a small improvement: increment the minor version
- [ ] a new feature: increment the minor version
- [ ] an incompatible (non-backwards compatible) API change: increment the major version

## Small Change

- [x] To merge, I will use "Squash and merge". That is, this change should be a single commit.

### 1. Does this do what we want it to do?

Objectives:
- Prevent confusing error messages from MPAS-Analysis when the conservation check is not enabled in E3SM runs

Required:
- [x] Product Management: I have confirmed with the stakeholders that the objectives above are correct and complete.
- [ ] Testing: I have added or modified at least one "min-case" configuration file to test this change. Every objective above is represented in at least one cfg.
- [ ] Testing: I have considered likely and/or severe edge cases and have included them in testing.


### 2. Are the implementation details accurate & efficient?

Required:
- [x] Logic: I have visually inspected the entire pull request myself.
- [ ] Logic: I have left GitHub comments highlighting important pieces of code logic. I have had these code blocks reviewed by at least one other team member.

### 3. Is this well documented?

Required:
- [x] Documentation: by looking at the docs, a new user could easily understand the functionality introduced by this pull request.

### 4. Is this code clean?

Required:
- [x] Readability: The code is as simple as possible and well-commented, such that a new team member could understand what's happening.
- [ ] Pre-commit checks: All the pre-commits checks have passed.
