### PR TITLE
Use Unified unless specified otherwise

### DIFF
--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -283,13 +283,16 @@ def generate_cfgs(unified_testing=False, dry_run=False):
     )
     expansions = get_expansions()
     if unified_testing:
-        expansions["diags_environment_commands"] = expansions[
-            "environment_commands_test"
-        ]
         expansions["environment_commands"] = expansions["environment_commands_test"]
-        expansions["global_time_series_environment_commands"] = expansions[
-            "environment_commands_test"
-        ]
+        # Use Unified for e3sm_diags and global_time_series unless we specify otherwise
+        if expansions["diags_environment_commands"] == "":
+            expansions["diags_environment_commands"] = expansions[
+                "environment_commands_test"
+            ]
+        if expansions["global_time_series_environment_commands"] == "":
+            expansions["global_time_series_environment_commands"] = expansions[
+                "environment_commands_test"
+            ]
     else:
         # The cfg doesn't need this line,
         # but it would be difficult to only write environment_commands in the unified_testing case.


### PR DESCRIPTION
## Summary

Objectives:
- For Unified testing, use Unified for `e3sm_diags` and `global_time_series` unless specified otherwise.

Issue resolution:
- Addresses the note at https://github.com/E3SM-Project/zppy/pull/664/files#r1934521913

Select one: This pull request is...
- [ ] a bug fix: increment the patch version
- [x] a small improvement: increment the minor version
- [ ] a new feature: increment the minor version
- [ ] an incompatible (non-backwards compatible) API change: increment the major version

## Small Change

- [x] To merge, I will use "Squash and merge". That is, this change should be a single commit.
- [x] Logic: I have visually inspected the entire pull request myself.
- [x] Pre-commit checks: All the pre-commits checks have passed.