### PR TITLE
Add min-case cfg for deprecated parameters

### DIFF
--- a/tests/integration/generated/test_min_case_deprecated_parameters_chrysalis.cfg
+++ b/tests/integration/generated/test_min_case_deprecated_parameters_chrysalis.cfg
@@ -1,0 +1,48 @@
+[default]
+case = "v3.LR.historical_0051"
+constraint = ""
+dry_run = True # Exlcusively testing with dry_run
+environment_commands = ""
+fail_on_dependency_skip = True
+guess_path_parameters = False
+guess_section_parameters = False
+input = /lcrc/group/e3sm2/ac.wlin//E3SMv3/v3.LR.historical_0051
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "/lcrc/group/e3sm/ac.forsyth2/zppy_weekly_comprehensive_v3_output/unique_id/v3.LR.historical_0051"
+partition = "debug"
+qos = "regular"
+www = "/lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_weekly_comprehensive_v3_www/unique_id"
+years = "1985:1989:2",
+
+[ts]
+active = True
+e3sm_to_cmip_environment_commands = "" # DEPRECATED in https://github.com/E3SM-Project/zppy/pull/650
+ts_fmt = "cmip" # DEPRECATED in https://github.com/E3SM-Project/zppy/pull/650
+walltime = "00:30:00"
+
+  [[ atm_monthly_180x360_aave ]]
+  frequency = "monthly"
+  input_files = "eam.h0"
+  input_subdir = "archive/atm/hist"
+
+# TODO: Add "tc_analysis" back in after empty dat is resolved.
+# [tc_analysis]
+# active = True
+# scratch = "" # DEPRECATED in https://github.com/E3SM-Project/zppy/pull/654
+# walltime = "00:30:00"
+
+[global_time_series]
+active = True
+atmosphere_only = "False" # DEPRECATED in https://github.com/E3SM-Project/zppy/pull/654
+climo_years = "1985-1989", "1990-1995",
+environment_commands = "source <INSERT PATH TO CONDA>/conda.sh; conda activate <INSERT ENV NAME>"
+experiment_name = "v3.LR.historical_0051"
+figstr = "v3.LR.historical_0051"
+moc_file=mocTimeSeries_1985-1995.nc
+plots_lnd = "FSH,RH2M,LAISHA,LAISUN,QINTR,QOVER,QRUNOFF,QSOIL,QVEGE,QVEGT,SOILWATER_10CM,TSA,H2OSNO,TOTLITC,CWDC,SOIL1C,SOIL2C,SOIL3C,SOIL4C,WOOD_HARVESTC,TOTVEGC,NBP,GPP,AR,HR"
+plot_names = "" # DEPRECATED in https://github.com/E3SM-Project/zppy/pull/654
+ts_num_years = 5
+ts_years = "1985-1989", "1985-1995",
+walltime = "00:30:00"
+years = "1985-1995",

--- a/tests/integration/template_min_case_deprecated_parameters.cfg
+++ b/tests/integration/template_min_case_deprecated_parameters.cfg
@@ -1,0 +1,48 @@
+[default]
+case = "#expand case_name#"
+constraint = "#expand constraint#"
+dry_run = True # Exlcusively testing with dry_run
+environment_commands = "#expand environment_commands#"
+fail_on_dependency_skip = True
+guess_path_parameters = False
+guess_section_parameters = False
+input = #expand user_input_v3#/E3SMv3/#expand case_name#
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "#expand user_output#zppy_weekly_comprehensive_v3_output/#expand unique_id#/#expand case_name#"
+partition = "#expand partition_short#"
+qos = "#expand qos_short#"
+www = "#expand user_www#zppy_weekly_comprehensive_v3_www/#expand unique_id#"
+years = "1985:1989:2",
+
+[ts]
+active = True
+e3sm_to_cmip_environment_commands = "" # DEPRECATED in https://github.com/E3SM-Project/zppy/pull/650
+ts_fmt = "cmip" # DEPRECATED in https://github.com/E3SM-Project/zppy/pull/650
+walltime = "00:30:00"
+
+  [[ atm_monthly_180x360_aave ]]
+  frequency = "monthly"
+  input_files = "eam.h0"
+  input_subdir = "archive/atm/hist"
+
+# TODO: Add "tc_analysis" back in after empty dat is resolved.
+# [tc_analysis]
+# active = True
+# scratch = "" # DEPRECATED in https://github.com/E3SM-Project/zppy/pull/654
+# walltime = "00:30:00"
+
+[global_time_series]
+active = True
+atmosphere_only = "False" # DEPRECATED in https://github.com/E3SM-Project/zppy/pull/654
+climo_years = "1985-1989", "1990-1995",
+environment_commands = "#expand global_time_series_environment_commands#"
+experiment_name = "#expand case_name#"
+figstr = "#expand case_name#"
+moc_file=mocTimeSeries_1985-1995.nc
+plots_lnd = "FSH,RH2M,LAISHA,LAISUN,QINTR,QOVER,QRUNOFF,QSOIL,QVEGE,QVEGT,SOILWATER_10CM,TSA,H2OSNO,TOTLITC,CWDC,SOIL1C,SOIL2C,SOIL3C,SOIL4C,WOOD_HARVESTC,TOTVEGC,NBP,GPP,AR,HR"
+plot_names = "" # DEPRECATED in https://github.com/E3SM-Project/zppy/pull/654
+ts_num_years = 5
+ts_years = "1985-1989", "1985-1995",
+walltime = "00:30:00"
+years = "1985-1995",

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -307,6 +307,7 @@ def generate_cfgs(unified_testing=False, dry_run=False):
     cfg_names = [
         "min_case_add_dependencies",
         "min_case_carryover_dependencies",
+        "min_case_deprecated_parameters",
         "min_case_tc_analysis_simultaneous_1",
         "min_case_tc_analysis_simultaneous_2",
         "min_case_tc_analysis_v2_simultaneous_1",


### PR DESCRIPTION
## Summary

Objectives:
- Add a "min-case" test for deprecated parameters.

Issue resolution:
- Address the question of how deprecated parameters are handled, noted at https://github.com/E3SM-Project/zppy/pull/673#discussion_r1941502932. As of `main` today, unused parameters appear to be simply ignored.

Select one: This pull request is...
- [ ] a bug fix: increment the patch version
- [x] a small improvement: increment the minor version
- [ ] a new feature: increment the minor version
- [ ] an incompatible (non-backwards compatible) API change: increment the major version

## Small Change

- [x] To merge, I will use "Squash and merge". That is, this change should be a single commit.
- [x] Logic: I have visually inspected the entire pull request myself.
- [x] Pre-commit checks: All the pre-commits checks have passed.