### PR TITLE
Remove MPAS-Analysis ocean conservation from default config

### DIFF
--- a/zppy/defaults/default.ini
+++ b/zppy/defaults/default.ini
@@ -276,7 +276,7 @@ anomalyRefYear = integer(default=1)
 cache = boolean(default=True)
 # Note that environment_commands needs to be the same for all related runs of [mpas_analysis].
 # For example, if years 1-50 are run using one environment and years 51-100 are run using another, MPAS-Analysis may fail.
-generate = string_list(default=list('all', 'no_landIceCavities', 'no_BGC', 'no_icebergs', 'no_min', 'no_max', 'no_sose', 'no_waves', 'no_eke', 'no_climatologyMapAntarcticMelt', 'no_regionalTSDiagrams', 'no_timeSeriesAntarcticMelt', 'no_timeSeriesOceanRegions', 'no_climatologyMapSose', 'no_woceTransects', 'no_soseTransects', 'no_geojsonTransects', 'no_oceanRegionalProfiles', 'no_hovmollerOceanRegions'))
+generate = string_list(default=list('all', 'no_landIceCavities', 'no_BGC', 'no_icebergs', 'no_min', 'no_max', 'no_sose', 'no_waves', 'no_eke', 'no_climatologyMapAntarcticMelt', 'no_regionalTSDiagrams', 'no_timeSeriesAntarcticMelt', 'no_timeSeriesOceanRegions', 'no_climatologyMapSose', 'no_woceTransects', 'no_soseTransects', 'no_geojsonTransects', 'no_oceanRegionalProfiles', 'no_hovmollerOceanRegions', 'no_oceanConservation'))
 mapMpiTasks = integer(default=6)
 mpaso_nml = string(default="mpaso_in")
 mpassi_nml = string(default="mpassi_in")


### PR DESCRIPTION
We do not plan to run with the conservation check on by default, so it doesn't make sense to have the analysis plots on by default.

Additionally, the v3 reference simulation is outputting conservation at a monthly interval, but MPAS-Analysis assumes it is being output at a daily interval, the new default.  Incorrect rolling averages were leading to no data being plotted.

## Summary

Objectives:
- Fix MPAS-Analysis plots of ocean conservation in E3SM-Unified 1.11.0rc5 that are empty (see https://github.com/E3SM-Project/zppy/discussions/634#discussioncomment-12020270)
- Disable ocean conservation plots by default because the required data will not be available in most E3SM v3 simulations.

Select one: This pull request is...
- [x] a bug fix: increment the patch version
- [ ] a small improvement: increment the minor version
- [ ] a new feature: increment the minor version
- [ ] an incompatible (non-backwards compatible) API change: increment the major version

## Small Change

- [x] To merge, I will use "Squash and merge". That is, this change should be a single commit.
- [x] Logic: I have visually inspected the entire pull request myself.
- [x] Pre-commit checks: All the pre-commits checks have passed.
