### PR TITLE
Remove climo_land_subsection

### DIFF
--- a/tests/integration/generated/test_min_case_e3sm_diags_lat_lon_land_mvm_2_chrysalis.cfg
+++ b/tests/integration/generated/test_min_case_e3sm_diags_lat_lon_land_mvm_2_chrysalis.cfg
@@ -34,7 +34,7 @@ short_name = "v3.LR.historical_0051"
 walltime = "5:00:00"
 
   [[ lnd_monthly_mvm_lnd ]]
-  climo_land_subsection = "land_monthly_climo"
+  climo_subsection = "land_monthly_climo"
   diff_title = "Difference"
   ref_final_yr = 1988
   ref_name = "v3.LR.historical_0051"

--- a/tests/integration/generated/test_weekly_comprehensive_v2_chrysalis.cfg
+++ b/tests/integration/generated/test_weekly_comprehensive_v2_chrysalis.cfg
@@ -146,7 +146,7 @@ years = "1982:1984:2",
 
   [[ lnd_monthly_mvm_lnd ]]
   # Test model-vs-model using the same files as the reference
-  climo_land_subsection = "land_monthly_climo"
+  climo_subsection = "land_monthly_climo"
   diff_title = "Difference"
   partition = "compute"
   qos = "regular"

--- a/tests/integration/generated/test_weekly_comprehensive_v3_chrysalis.cfg
+++ b/tests/integration/generated/test_weekly_comprehensive_v3_chrysalis.cfg
@@ -174,7 +174,7 @@ tc_obs = "/lcrc/group/e3sm/diagnostics/observations/Atm/tc-analysis/"
 
   [[ lnd_monthly_mvm_lnd ]]
   # Test model-vs-model using the same files as the reference
-  climo_land_subsection = "land_monthly_climo"
+  climo_subsection = "land_monthly_climo"
   diff_title = "Difference"
   partition = "compute"
   qos = "regular"

--- a/tests/integration/template_min_case_e3sm_diags_lat_lon_land_mvm_2.cfg
+++ b/tests/integration/template_min_case_e3sm_diags_lat_lon_land_mvm_2.cfg
@@ -34,7 +34,7 @@ short_name = "#expand case_name#"
 walltime = "#expand diags_walltime#"
 
   [[ lnd_monthly_mvm_lnd ]]
-  climo_land_subsection = "land_monthly_climo"
+  climo_subsection = "land_monthly_climo"
   diff_title = "Difference"
   ref_final_yr = 1988
   ref_name = "#expand case_name#"

--- a/tests/integration/template_weekly_comprehensive_v2.cfg
+++ b/tests/integration/template_weekly_comprehensive_v2.cfg
@@ -146,7 +146,7 @@ years = "1982:1984:2",
 
   [[ lnd_monthly_mvm_lnd ]]
   # Test model-vs-model using the same files as the reference
-  climo_land_subsection = "land_monthly_climo"
+  climo_subsection = "land_monthly_climo"
   diff_title = "Difference"
   partition = "#expand partition_long#"
   qos = "#expand qos_long#"

--- a/tests/integration/template_weekly_comprehensive_v3.cfg
+++ b/tests/integration/template_weekly_comprehensive_v3.cfg
@@ -174,7 +174,7 @@ tc_obs = "#expand diagnostics_base_path#/observations/Atm/tc-analysis/"
 
   [[ lnd_monthly_mvm_lnd ]]
   # Test model-vs-model using the same files as the reference
-  climo_land_subsection = "land_monthly_climo"
+  climo_subsection = "land_monthly_climo"
   diff_title = "Difference"
   partition = "#expand partition_long#"
   qos = "#expand qos_long#"

--- a/tests/test_zppy_e3sm_diags.py
+++ b/tests/test_zppy_e3sm_diags.py
@@ -483,6 +483,7 @@ def test_add_climo_dependencies():
     base: Dict[str, Any] = {"year1": 1980, "year2": 1990}
     sets = [
         "lat_lon",
+        "lat_lon_land",
         "zonal_mean_xy",
         "zonal_mean_2d",
         "polar",
@@ -504,17 +505,6 @@ def test_add_climo_dependencies():
     add_climo_dependencies(c, dependencies, "script_dir")
     assert dependencies == ["script_dir/climo_cdsub_1980-1990.status"]
     c = {"sets": ["diurnal_cycle"]}
-    c.update(base)
-    dependencies = []
-    with pytest.raises(ParameterNotProvidedError):
-        add_climo_dependencies(c, dependencies, "script_dir")
-
-    c = {"sets": ["lat_lon_land"], "climo_land_subsection": "lndsub"}
-    c.update(base)
-    dependencies = []
-    add_climo_dependencies(c, dependencies, "script_dir")
-    assert dependencies == ["script_dir/climo_lndsub_1980-1990.status"]
-    c = {"sets": ["lat_lon_land"]}
     c.update(base)
     dependencies = []
     with pytest.raises(ParameterNotProvidedError):

--- a/zppy/e3sm_diags.py
+++ b/zppy/e3sm_diags.py
@@ -233,6 +233,10 @@ def add_climo_dependencies(
     depend_on_climo: Set[str] = set(
         [
             "lat_lon",
+            # Note: often `lat_lon_land` will require a different climo_subsection
+            # than the other sets (e.g., a climo subsection that includes land).
+            # That means this set will often need to be run as a separate subtask.
+            "lat_lon_land",
             "zonal_mean_xy",
             "zonal_mean_2d",
             "polar",
@@ -258,13 +262,6 @@ def add_climo_dependencies(
         dependencies.append(
             os.path.join(
                 script_dir, f"climo_{c['climo_diurnal_subsection']}{status_suffix}"
-            )
-        )
-    if "lat_lon_land" in c["sets"]:
-        check_parameter_defined(c, "climo_land_subsection")
-        dependencies.append(
-            os.path.join(
-                script_dir, f"climo_{c['climo_land_subsection']}{status_suffix}"
             )
         )
     if "tc_analysis" in c["sets"]:


### PR DESCRIPTION
## Summary

Objectives:
- Remove `climo_land_subsection`, opting to use the existing `climo_subsection` instead.

Issue resolution:
- Resolves https://github.com/E3SM-Project/zppy/issues/669#issuecomment-2635055254.

Select one: This pull request is...
- [ ] a bug fix: increment the patch version
- [x] a small improvement: increment the minor version
- [ ] a new feature: increment the minor version
- [ ] an incompatible (non-backwards compatible) API change: increment the major version

## Small Change

- [x] To merge, I will use "Squash and merge". That is, this change should be a single commit.
- [x] Logic: I have visually inspected the entire pull request myself.
- [x] Pre-commit checks: All the pre-commits checks have passed.