### PR TITLE
Remove npo flag

### DIFF
--- a/zppy/templates/ts.bash
+++ b/zppy/templates/ts.bash
@@ -62,7 +62,7 @@ if grep -q "*" input.txt; then
 fi
 # Generate time series files
 # If the user-defined parameter "vars" is "", then ${vars}, defined above, will be too.
-cat input.txt | ncclimo --npo \
+cat input.txt | ncclimo \
 -c {{ case }} \
 {%- if vars != '' %}
 -v ${vars} \


### PR DESCRIPTION
## Summary

Objectives:
- Remove the `--npo` flag.

Issue resolution:
- This was an omission in [#663](https://github.com/E3SM-Project/zppy/pull/663/files), which was trying to undo https://github.com/E3SM-Project/zppy/commit/d2e5bd9b5491a6ab3c332c41a5bac425162bfef3#diff-3c2c1a7e3bccf0e902062cd7d298f00f920acd2f93dac3e19ad23fe98f504465. That PR only removed 1 of the 2 components from the previous commit.

Select one: This pull request is...
- [x] a bug fix: increment the patch version
- [ ] a small improvement: increment the minor version
- [ ] a new feature: increment the minor version
- [ ] an incompatible (non-backwards compatible) API change: increment the major version

## Small Change

- [ ] To merge, I will use "Squash and merge". That is, this change should be a single commit.
- [x] Logic: I have visually inspected the entire pull request myself.
- [x] Pre-commit checks: All the pre-commits checks have passed.