### PR TITLE
Improve res handling in tc_analysis

### DIFF
--- a/tests/integration/generated/test_min_case_tc_analysis_only_chrysalis.cfg
+++ b/tests/integration/generated/test_min_case_tc_analysis_only_chrysalis.cfg
@@ -1,0 +1,23 @@
+[default]
+case = "v3.LR.historical_0051"
+constraint = ""
+dry_run = "False"
+environment_commands = ""
+input = /lcrc/group/e3sm2/ac.wlin//E3SMv3/v3.LR.historical_0051
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "/lcrc/group/e3sm/ac.forsyth2/zppy_min_case_tc_analysis_only_output/unique_id/v3.LR.historical_0051"
+partition = "debug"
+qos = "regular"
+www = "/lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_min_case_tc_analysis_only_www/unique_id"
+years = "1985:1987:2",
+
+[tc_analysis]
+active = True
+walltime = "00:30:00"
+# first_file=/lcrc/group/e3sm2/ac.wlin//E3SMv3/v3.LR.historical_0051/archive/atm/hist/v3.LR.historical_0051.eam.h2.1850-01-01-00000.nc
+# topography_file=/lcrc/group/e3sm/data/inputdata/atm/cam/topo/USGS-gtopo30_ne30np4pg2_x6t-SGH.c20210614.nc
+# grid=ne30np4pg2
+# Inferring res from grid
+# res=30
+# pg2=true

--- a/tests/integration/generated/test_min_case_tc_analysis_res_chrysalis.cfg
+++ b/tests/integration/generated/test_min_case_tc_analysis_res_chrysalis.cfg
@@ -1,0 +1,23 @@
+[default]
+case = "v3.LR.historical_0051"
+constraint = ""
+dry_run = "False"
+environment_commands = ""
+input = /lcrc/group/e3sm2/ac.wlin//E3SMv3/v3.LR.historical_0051
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "/lcrc/group/e3sm/ac.forsyth2/zppy_min_case_tc_analysis_res_output/unique_id/v3.LR.historical_0051"
+partition = "debug"
+qos = "regular"
+www = "/lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_min_case_tc_analysis_res_www/unique_id"
+years = "1985:1987:2",
+
+[tc_analysis]
+active = True
+res="30"
+walltime = "00:30:00"
+# first_file=/lcrc/group/e3sm2/ac.wlin//E3SMv3/v3.LR.historical_0051/archive/atm/hist/v3.LR.historical_0051.eam.h2.1850-01-01-00000.nc
+# topography_file=/lcrc/group/e3sm/data/inputdata/atm/cam/topo/USGS-gtopo30_ne30np4pg2_x6t-SGH.c20210614.nc
+# grid=ne30np4pg2
+# res=30
+# pg2=true

--- a/tests/integration/template_min_case_tc_analysis_only.cfg
+++ b/tests/integration/template_min_case_tc_analysis_only.cfg
@@ -1,0 +1,23 @@
+[default]
+case = "#expand case_name#"
+constraint = "#expand constraint#"
+dry_run = "#expand dry_run#"
+environment_commands = "#expand environment_commands#"
+input = #expand user_input_v3#/E3SMv3/#expand case_name#
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "#expand user_output#zppy_min_case_tc_analysis_only_output/#expand unique_id#/#expand case_name#"
+partition = "#expand partition_short#"
+qos = "#expand qos_short#"
+www = "#expand user_www#zppy_min_case_tc_analysis_only_www/#expand unique_id#"
+years = "1985:1987:2",
+
+[tc_analysis]
+active = True
+walltime = "00:30:00"
+# first_file=/lcrc/group/e3sm2/ac.wlin//E3SMv3/v3.LR.historical_0051/archive/atm/hist/v3.LR.historical_0051.eam.h2.1850-01-01-00000.nc
+# topography_file=/lcrc/group/e3sm/data/inputdata/atm/cam/topo/USGS-gtopo30_ne30np4pg2_x6t-SGH.c20210614.nc
+# grid=ne30np4pg2
+# Inferring res from grid
+# res=30
+# pg2=true

--- a/tests/integration/template_min_case_tc_analysis_res.cfg
+++ b/tests/integration/template_min_case_tc_analysis_res.cfg
@@ -1,0 +1,23 @@
+[default]
+case = "#expand case_name#"
+constraint = "#expand constraint#"
+dry_run = "#expand dry_run#"
+environment_commands = "#expand environment_commands#"
+input = #expand user_input_v3#/E3SMv3/#expand case_name#
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "#expand user_output#zppy_min_case_tc_analysis_res_output/#expand unique_id#/#expand case_name#"
+partition = "#expand partition_short#"
+qos = "#expand qos_short#"
+www = "#expand user_www#zppy_min_case_tc_analysis_res_www/#expand unique_id#"
+years = "1985:1987:2",
+
+[tc_analysis]
+active = True
+res="30"
+walltime = "00:30:00"
+# first_file=/lcrc/group/e3sm2/ac.wlin//E3SMv3/v3.LR.historical_0051/archive/atm/hist/v3.LR.historical_0051.eam.h2.1850-01-01-00000.nc
+# topography_file=/lcrc/group/e3sm/data/inputdata/atm/cam/topo/USGS-gtopo30_ne30np4pg2_x6t-SGH.c20210614.nc
+# grid=ne30np4pg2
+# res=30
+# pg2=true

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -315,6 +315,8 @@ def generate_cfgs(unified_testing=False, dry_run=False):
         "min_case_add_dependencies",
         "min_case_carryover_dependencies",
         "min_case_deprecated_parameters",
+        "min_case_tc_analysis_only",
+        "min_case_tc_analysis_res",
         "min_case_tc_analysis_simultaneous_1",
         "min_case_tc_analysis_simultaneous_2",
         "min_case_tc_analysis_v2_simultaneous_1",

--- a/zppy/defaults/default.ini
+++ b/zppy/defaults/default.ini
@@ -152,6 +152,9 @@ input_component = string(default="")
 [tc_analysis]
 # NOTE: always overrides value in [default]
 input_files = string(default="eam.h2")
+# Resolution to use for `--res` option.
+# If not set, zppy will attempt to infer this value from the topography file.
+res = string(default="")
 
 [e3sm_diags]
 # See https://e3sm-project.github.io/e3sm_diags/_build/html/master/available-parameters.html

--- a/zppy/templates/tc_analysis.bash
+++ b/zppy/templates/tc_analysis.bash
@@ -25,18 +25,26 @@ atm_name={{ atm_name }}
 
 # Determine res and pg2
 first_file=`echo $(ls ${drc_in}/${caseid}.{{ input_files }}.*.nc | head -n 1)`
+echo "first_file=${first_file}"
 topography_file=`echo $(ncks --trd -M -m ${first_file} | grep -E -i "^global attribute [0-9]+: topography_file" | cut -f 11- -d ' ' | sort)`
-res=""
+echo "topography_file=${topography_file}"
+res={{ res }}
 pg2=false
-if [[ $topography_file =~ /.*_(.*)_.*nc ]]; then
+if [[ $topography_file =~ /[^_]*_([^_]*)_.*nc ]]; then
     grid=${BASH_REMATCH[1]}
-    if [[ $grid =~ ne([0-9]*) ]]; then
-	res=${BASH_REMATCH[1]}
+    echo "grid=${grid}"
+    if [[ -z "${res}" ]]; then
+        echo "Inferring res from grid"
+        if [[ $grid =~ ne([0-9]*) ]]; then
+            res=${BASH_REMATCH[1]}
+        fi
     fi
     if [[ $grid =~ pg2 ]]; then
 	pg2=true
     fi
 fi
+echo "res=${res}"
+echo "pg2=${pg2}"
 
 mkdir -p $result_dir
 file_name=${caseid}_${start}_${end}


### PR DESCRIPTION
## Summary

Objectives:
- Add `res` parameter for users to set resolution explicitly, in the case that `zppy` can't infer it.
- Fix the regex pattern matching that caused incorrect resolution inference for some grids.

Issue resolution:
- Closes #688

Select one: This pull request is...
- [x] a bug fix: increment the patch version
- [x] a small improvement: increment the minor version
- [ ] a new feature: increment the minor version
- [ ] an incompatible (non-backwards compatible) API change: increment the major version

## Small Change

- [x] To merge, I will use "Squash and merge". That is, this change should be a single commit.
- [x] Logic: I have visually inspected the entire pull request myself.
- [x] Pre-commit checks: All the pre-commits checks have passed.