### PR TITLE
Fix ilamb template for piControl year range (with leading0)

### DIFF
--- a/zppy/templates/ilamb.bash
+++ b/zppy/templates/ilamb.bash
@@ -40,10 +40,12 @@ lnd_ts_for_ilamb={{ output }}/post/lnd/{{ ts_land_grid }}/cmip_ts/monthly/
 atm_ts_for_ilamb={{ output }}/post/atm/{{ ts_atm_grid }}/cmip_ts/monthly/
 # Go through the time series files for between year1 and year2,
 # using a step size equal to the number of years per time series file
-for year in `seq ${Y1} {{ ts_num_years }} ${Y2}`;
+start_year=$(echo $Y1 | sed 's/^0*//')
+end_year=$(echo $Y2 | sed 's/^0*//')
+for year in `seq $start_year {{ ts_num_years }} $end_year`;
 do
-  start_year=`printf "%04d" ${year}`
   end_year_int=$((${start_year} + {{ ts_num_years }} - 1))
+  start_year=`printf "%04d" ${year}`
   end_year=`printf "%04d" ${end_year_int}`
   echo "Copying files for ${start_year} to ${end_year}"
   cp -s ${lnd_ts_for_ilamb}/*_*_*_*_*_*_${start_year}??-${end_year}??.nc .


### PR DESCRIPTION
## Summary
When testing a config for piControl run, I found a bug that with year start/end with leading 0s, example "0451" to "0500", the ilamb template would mis-interprate the years and cause the run to fail. 

This PR did minimal change to convert years with leading 0 by removing without other refactoring that is probably nice to have. 

Issue resolution:
- Closes #<ISSUE_NUMBER_HERE>

Select one: This pull request is...
- [x] a bug fix: increment the patch version
- [ ] a small improvement: increment the minor version
- [ ] a new feature: increment the minor version
- [ ] an incompatible (non-backwards compatible) API change: increment the major version

Please fill out either the "Small Change" or "Big Change" section (the latter includes the numbered subsections), and delete the other.

## Small Change

- [ ] To merge, I will use "Squash and merge". That is, this change should be a single commit.
- [ ] Logic: I have visually inspected the entire pull request myself.
- [ ] Pre-commit checks: All the pre-commits checks have passed.

## Big Change

- [ ] To merge, I will use "Create a merge commit". That is, this change is large enough to require multiple units of work (i.e., it should be multiple commits).

### 1. Does this do what we want it to do?

Required:
- [ ] Product Management: I have confirmed with the stakeholders that the objectives above are correct and complete.
- [ ] Testing: I have added or modified at least one "min-case" configuration file to test this change. Every objective above is represented in at least one cfg.
- [ ] Testing: I have considered likely and/or severe edge cases and have included them in testing.

If applicable:
- [ ] Testing: this pull request introduces an important feature or bug fix that we _must_ test often. I have updated the weekly-test configuration files, not just a "min-case" one.
- [ ] Testing: this pull request adds at least one new possible parameter to the cfg. I have tested using this parameter with and without any other parameter that may interact with it.

### 2. Are the implementation details accurate & efficient?

Required:
- [ ] Logic: I have visually inspected the entire pull request myself.
- [ ] Logic: I have left GitHub comments highlighting important pieces of code logic. I have had these code blocks reviewed by at least one other team member.

If applicable:
- [ ] Dependencies: This pull request introduces a new dependency. I have discussed this requirement with at least one other team member. The dependency is noted in `zppy/conda`, not just an `import` statement.

### 3. Is this well documented?

Required:
- [ ] Documentation: by looking at the docs, a new user could easily understand the functionality introduced by this pull request.

### 4. Is this code clean?

Required:
- [ ] Readability: The code is as simple as possible and well-commented, such that a new team member could understand what's happening.
- [ ] Pre-commit checks: All the pre-commits checks have passed.

If applicable:
- [ ] Software architecture: I have discussed relevant trade-offs in design decisions with at least one other team member. It is unlikely that this pull request will increase tech debt.
