### PR TITLE
Applying computer vision to image checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ zppy.egg-info/
 *~
 \#*
 
+cv_prototype_summary.md
 examples/example_compy.cfg
 test_images_summary.md
 test_*_output

--- a/conda/dev.yml
+++ b/conda/dev.yml
@@ -14,6 +14,10 @@ dependencies:
   - mache>=1.5.0
   - mpas_tools>=0.15.0
   - pillow=9.2.0
+  # CV Prototype
+  # ============
+  - opencv
+  - scikit-learn
   # Testing
   # =======================
   - pytest

--- a/tests/integration/image_checker.py
+++ b/tests/integration/image_checker.py
@@ -1,7 +1,7 @@
 import os
 import shutil
 from math import ceil
-from typing import Dict, List, Tuple
+from typing import Any, Dict, List, Tuple
 
 import cv2
 import matplotlib.backends.backend_pdf
@@ -10,6 +10,10 @@ import numpy as np
 from mache import MachineInfo
 from matplotlib import pyplot as plt
 from PIL import Image, ImageChops, ImageDraw
+from sklearn.cluster import DBSCAN, AgglomerativeClustering, KMeans
+from sklearn.decomposition import PCA
+from sklearn.manifold import TSNE
+from sklearn.preprocessing import StandardScaler
 
 
 # Classes #####################################################################
@@ -87,8 +91,11 @@ def set_up_and_run_image_checker(
 # Generalized image checking ##################################################
 
 
-def check_images(parameters: Parameters, prefix: str):
-    test_results = _check_mismatched_images(parameters, prefix)
+def check_images(parameters: Parameters, prefix: str, cv_dict: Dict[str, Any] = {}):
+    if cv_dict:
+        test_results = _cv_check_mismatched_images(parameters, prefix, cv_dict)
+    else:
+        test_results = _check_mismatched_images(parameters, prefix)
     diff_subdir = f"{parameters.diff_dir}/{prefix}"
     if not os.path.exists(diff_subdir):
         os.makedirs(diff_subdir, exist_ok=True)
@@ -160,25 +167,14 @@ def _check_mismatched_images(
                     parameters.expected_images_dir, image_name
                 )
 
-                USE_CV = True
-                if USE_CV:
-                    _cv_compare_actual_and_expected(
-                        missing_images,
-                        mismatched_images,
-                        image_name,
-                        path_to_actual_png,
-                        path_to_expected_png,
-                        parameters.diff_dir,
-                    )
-                else:
-                    _compare_actual_and_expected(
-                        missing_images,
-                        mismatched_images,
-                        image_name,
-                        path_to_actual_png,
-                        path_to_expected_png,
-                        parameters.diff_dir,
-                    )
+                _compare_actual_and_expected(
+                    missing_images,
+                    mismatched_images,
+                    image_name,
+                    path_to_actual_png,
+                    path_to_expected_png,
+                    parameters.diff_dir,
+                )
 
     verbose: bool = False
     if verbose:
@@ -388,26 +384,9 @@ def _make_image_diff_grid(diff_subdir, pdf_name="image_diff_grid.pdf", rows_per_
 
 
 # CV proof-of-concept #########################################################
-"""
-cd /home/ac.forsyth2/ez/zppy
-lcrc_conda # alias to set up conda
-pre-commit run --all-files
-git add -A
-conda clean --all --y
-conda env create -f conda/dev.yml -n zppy-hackathon-20250707-with-cv
-conda activate zppy-hackathon-20250707-with-cv
-pip install .
-
-# Update try_num
-pre-commit run --all-files
-git add -A
-python tests/integration/image_checker.py
-diff /lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/cv_prototype/diff_try9/e3sm_diags/missing_images.txt /lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/cv_prototype/diff_try1/e3sm_diags/missing_images.txt
-diff /lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/cv_prototype/diff_try9/e3sm_diags/mismatched_images.txt /lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/cv_prototype/diff_try1/e3sm_diags/mismatched_images.txt
-"""
 
 
-def cv_prototype(try_num: int):
+def cv_prototype(try_num: int, cv_dict: Dict[str, Any]):
     print("Computer Vision Prototype for image checker")
     """
     cd /lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2
@@ -455,89 +434,150 @@ def cv_prototype(try_num: int):
     for key in d:
         print(f"{key}: {d[key]}")
     parameters: Parameters = Parameters(d)
-    test_results: Results = check_images(parameters, "e3sm_diags")
-    # test_results_dict: Dict[str, Results] = {"e3sm_diags": test_results}
-    # construct_markdown_summary_table(test_results_dict, "cv_prototype_summary.md")
-    # | e3sm_diags | 1713 | 1644 | 12 | 57 | /lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/cv_prototype/diff_try{try_num}/e3sm_diags |
-
-    # Try           | Total | Correct | Missing | Mismatched | Notes
-    # 1,2: original | 1713 | 1644    | 12       | 57         |
-    # 7,9: Step 1   | 1713 | 1632    | 12       | 69         | +12 mismatched
+    # TODO: if/when merging, do the following:
+    # To use the CV-version of the image checker for actual integration testing,
+    # we'd simply need to update `set_up_and_run_image_checker` from
+    # `check_images(parameters, task)` to `check_images(parameters, task, use_cv=cv_dict)`
+    test_results: Results = check_images(parameters, "e3sm_diags", cv_dict=cv_dict)
+    # Try                       | Total | Correct | Missing | Mismatched | Notes
+    # 1,2: original             | 1713 | 1644    | 12       | 57         |
+    # 7,9: compute_diff_image   | 1713 | 1632    | 12       | 69         | +12 mismatched
+    # 29,30,31,32: clustering   | 1713 | 1632    | 12       | 69         |
+    print(f"Done with try {try_num}")
     assert test_results.image_count_total == 1713
     assert test_results.image_count_missing == 12
-    assert test_results.image_count_mismatched == 57
-    assert test_results.image_count_correct == 1644
+    assert test_results.image_count_mismatched == 69
+    assert test_results.image_count_correct == 1632
 
 
-# Modified from LivChat code ###
+def _cv_check_mismatched_images(
+    parameters: Parameters, prefix: str, cv_dict: Dict[str, Any]
+) -> Results:
+    missing_images: List[str] = []
+    mismatched_images: List[str] = []
+    features: List[np.ndarray] = []
+    diff_image_paths: List[str] = []
+
+    counter = 0
+    print(f"Opening expected images file {parameters.expected_images_list}")
+    with open(parameters.expected_images_list) as f:
+        print(f"Reading expected images file {parameters.expected_images_list}")
+        # Step 1: Process all pairs and collect diff regions
+        for line in f:
+            image_name = line.strip("./").strip("\n")
+            if image_name.startswith(prefix):
+                counter += 1
+                if counter % 250 == 0:
+                    print("On line #", counter)
+                path_to_actual_png = os.path.join(
+                    parameters.actual_images_dir, image_name
+                )
+                path_to_expected_png = os.path.join(
+                    parameters.expected_images_dir, image_name
+                )
+
+                # Compare a single image's actual & expected, compute diffs
+                _cv_compare_actual_and_expected(
+                    missing_images,
+                    mismatched_images,
+                    image_name,
+                    path_to_actual_png,
+                    path_to_expected_png,
+                    parameters.diff_dir,
+                    features,
+                    diff_image_paths,
+                    cv_dict,
+                )
+
+    # Compare all the diffs we found
+    # Pass in parallel lists: features & diff_image_paths
+    group_diffs(features, diff_image_paths, parameters.diff_dir, cv_dict)
+
+    verbose: bool = False
+    if verbose:
+        if missing_images:
+            print("Missing images:")
+            for i in missing_images:
+                print(i)
+        if mismatched_images:
+            print("Mismatched images:")
+            for i in mismatched_images:
+                print(i)
+
+    # Count summary
+    print(f"Total: {counter}")
+    print(f"Number of missing images: {len(missing_images)}")
+    print(f"Number of mismatched images: {len(mismatched_images)}")
+    print(
+        f"Number of correct images: {counter - len(missing_images) - len(mismatched_images)}"
+    )
+    test_results = Results(
+        parameters.diff_dir, prefix, counter, missing_images, mismatched_images
+    )
+
+    # Make diff_dir readable
+    if os.path.exists(parameters.diff_dir):
+        # Execute permission for user is needed to remove diff_dir if we're re-running the image checks.
+        # Execute permission for others is needed to make diff_dir visible on the web server.
+        # 7 - rwx for user
+        # 5 - r-x for group, others
+        _chmod_recursive(parameters.diff_dir, 0o755)
+    else:
+        # diff_dir won't exist if all the expected images are missing
+        # That is, if we're in this case, we expect the following:
+        assert len(missing_images) == counter
+
+    return test_results
 
 
 def _cv_compare_actual_and_expected(
-    missing_images,
-    mismatched_images,
-    image_name,
-    path_to_actual_png,
-    path_to_expected_png,
-    diff_dir,
+    missing_images: List[str],
+    mismatched_images: List[str],
+    image_name: str,
+    path_to_actual_png: str,
+    path_to_expected_png: str,
+    diff_dir: str,
+    features: List[np.ndarray],
+    diff_image_paths: List[str],
+    cv_dict: Dict[str, Any],
 ):
     if not os.path.exists(path_to_actual_png):
         missing_images.append(image_name)
         return
-    actual_image: np.ndarray = cv2.imread(str(path_to_actual_png))
-    if actual_image is None:
-        raise ValueError(f"cv2.imread failed to read {path_to_actual_png}")
-    expected_image = cv2.imread(str(path_to_expected_png))
-    # diff: np.ndarray
+
+    # The image is present in actual; let's see if it matches expected
+    actual_image: np.ndarray
+    expected_image: np.ndarray
+    actual_image, expected_image = get_images(path_to_actual_png, path_to_expected_png)
+    diff: np.ndarray
     mask: np.ndarray
-    _, mask = compute_diff_image(expected_image, actual_image)
+    diff, mask = compute_diff_image(actual_image, expected_image, cv_dict)
     if not mask.any():
         # Images are close enough, call it a match
         return
-    # # diff != 0 => boolean array where True indicates diff[i,j] is not 0
-    # # count_nonzero counts all the Trues
-    # num_nonzero_pixels = np.count_nonzero(diff != 0)
-    # width, height = diff.shape
-    # num_pixels = width * height
-    # threshold = num_nonzero_pixels / num_pixels
-    # # Threshold of mismatched pixels should be less than 0.02%
-    # if threshold >= 0.0002:
-    #     mismatched_images.append(image_name)
+
+    # The image does NOT match expected; let's compute the diff
     mismatched_images.append(image_name)
-    diff_dir_actual_png = os.path.join(diff_dir, f"{image_name}_actual.png")
-    # image_name could contain a number of subdirectories.
-    # So, let's make them.
-    os.makedirs(os.path.dirname(diff_dir_actual_png), exist_ok=True)
-    shutil.copy(
-        path_to_actual_png,
-        diff_dir_actual_png,
+    diff_dir_paths: Dict[str, str] = write_images(
+        diff_dir, image_name, path_to_actual_png, path_to_expected_png, diff
     )
-    diff_dir_expected_png = os.path.join(diff_dir, f"{image_name}_expected.png")
-    # image_name could contain a number of subdirectories.
-    # So, let's make them.
-    os.makedirs(os.path.dirname(diff_dir_expected_png), exist_ok=True)
-    shutil.copy(
-        path_to_expected_png,
-        diff_dir_expected_png,
-    )
-    # Draw red box around diff-area on each of: diff, actual, expected
-    # _draw_box(diff, diff, os.path.join(diff_dir, f"{image_name}_diff.png"))
-    # _draw_box(actual_image, diff, os.path.join(diff_dir, f"{image_name}_actual.png"))
-    # _draw_box(
-    #     expected_image, diff, os.path.join(diff_dir, f"{image_name}_expected.png")
-    # )
-
-    # keypoints, _ = detect_features(expected_image)
-    # clusters = cluster_diff_regions(mask)
-    # groupings = assign_clusters_to_features(clusters, keypoints)
-    # # Save diff image
-    # diff_name = output_dir / f"diff_{Path(path_to_expected_png).stem}.png"
-    # cv2.imwrite(str(diff_name), diff)
-    # print(f"Processed {image_name}: {path_to_expected_png} vs {path_to_actual_png}: {len(clusters)} diff regions grouped by features.")
+    # Update the parallel lists diff_image_paths & features
+    diff_image_paths.append(diff_dir_paths["diff"])
+    update_features(actual_image, diff, features, cv_dict)
 
 
-# Step 1: Compute Diff Images
+def get_images(
+    path_to_actual_png: str, path_to_expected_png: str
+) -> Tuple[np.ndarray, np.ndarray]:
+    actual_image: np.ndarray = cv2.imread(str(path_to_actual_png))
+    if actual_image is None:
+        raise ValueError(f"cv2.imread failed to read {path_to_actual_png}")
+    expected_image: np.ndarray = cv2.imread(str(path_to_expected_png))
+    return actual_image, expected_image
+
+
 def compute_diff_image(
-    expected_image: np.ndarray, actual_image: np.ndarray
+    actual_image: np.ndarray, expected_image: np.ndarray, cv_dict: Dict[str, Any]
 ) -> Tuple[np.ndarray, np.ndarray]:
     # Ensure both images are the same size
     if expected_image.shape != actual_image.shape:
@@ -555,50 +595,386 @@ def compute_diff_image(
     # That is, the fraction of mismatched pixels should be less than 0.02%
     # This is a little different.
     # Here, we're seeing how high the grayscale value is for each pixel in the diff.
-    # If it's > 30, we add it to the mask.
-    _, mask = cv2.threshold(gray_diff, 30, 255, cv2.THRESH_BINARY)
+    # If it's > gray_diff_threshold, we add it to the mask.
+    _, mask = cv2.threshold(
+        gray_diff, cv_dict["gray_diff_threshold"], 255, cv2.THRESH_BINARY
+    )
     if len(mask.shape) != 2:
         raise ValueError(f"mask.shape={mask.shape} should have 2 dimensions")
     return diff, mask
 
 
-# # Step 2: Feature Detection/Segmentation
-# # NOTE: I imagine this will take quite a bit of troubleshooting to actually get working! There are many many plot types, each with different features. Will this detect them accurately?
-# def detect_features(img):
-#     sift = cv2.SIFT_create()
-#     keypoints, descriptors = sift.detectAndCompute(img, None)
-#     return keypoints, descriptors
+def write_images(
+    diff_dir: str,
+    image_name: str,
+    path_to_actual_png: str,
+    path_to_expected_png: str,
+    diff: np.ndarray,
+) -> Dict[str, str]:
+    diff_dir_paths: Dict[str, str] = {
+        "actual": os.path.join(diff_dir, f"{image_name}_actual.png"),
+        "expected": os.path.join(diff_dir, f"{image_name}_expected.png"),
+        "diff": os.path.join(diff_dir, f"{image_name}_diff.png"),
+    }
 
-# # Step 3: Cluster Diff Pixels
-# # NOTE: how would we ever know what `n_clusters` should be? Without that would we need to resort to classification rather than clustering (i.e., needing to hand-label a training set)?
-# def cluster_diff_regions(mask, n_clusters=3):
-#     # Find nonzero (diff) pixels
-#     ys, xs = np.nonzero(mask)
-#     coords = np.column_stack((xs, ys))
-#     if len(coords) == 0:
-#         return []
-#     kmeans = KMeans(n_clusters=min(n_clusters, len(coords)), random_state=42)
-#     labels = kmeans.fit_predict(coords)
-#     clusters = [coords[labels == i] for i in range(n_clusters)]
-#     return clusters
+    # image_name could contain a number of subdirectories under diff_dir
+    # So, let's be sure to make them.
+    os.makedirs(os.path.dirname(diff_dir_paths["actual"]), exist_ok=True)
 
-# # Step 4: Group Diffs by Feature
-# def assign_clusters_to_features(clusters, keypoints):
-#     feature_coords = np.array([kp.pt for kp in keypoints])
-#     groupings = {}
-#     for i, cluster in enumerate(clusters):
-#         if len(feature_coords) == 0 or len(cluster) == 0:
-#             groupings[i] = None
-#             continue
-#         # Find the closest feature for each cluster centroid
-#         centroid = np.mean(cluster, axis=0)
-#         distances = np.linalg.norm(feature_coords - centroid, axis=1)
-#         closest_feature_idx = np.argmin(distances)
-#         groupings[i] = keypoints[closest_feature_idx]
-#     return groupings
+    shutil.copy(path_to_actual_png, diff_dir_paths["actual"])
+    shutil.copy(
+        path_to_expected_png,
+        diff_dir_paths["expected"],
+    )
+    cv2.imwrite(diff_dir_paths["diff"], diff)
+
+    return diff_dir_paths
+
+
+def update_features(
+    actual_image: np.ndarray,
+    diff: np.ndarray,
+    features: List[np.ndarray],
+    cv_dict: Dict[str, Any],
+):
+    diff_feat: np.ndarray = extract_features(diff, cv_dict)
+    if cv_dict["extract_diff_features_only"]:
+        features.append(diff_feat)
+    else:
+        actual_feat: np.ndarray = extract_features(actual_image, cv_dict)
+        combined_feat: np.ndarray = np.concatenate([actual_feat, diff_feat])
+        features.append(combined_feat)
+
+
+def extract_features(img: np.ndarray, cv_dict: Dict[str, Any]) -> np.ndarray:
+    bins: int
+    if cv_dict["feature_extraction_algorithm"] == "simple_hist":
+        # Extract a normalized color histogram from an image.
+        bins = cv_dict["simple_hist_bins"]
+        hist = cv2.calcHist(
+            [img], [0, 1, 2], None, [bins, bins, bins], [0, 180, 0, 256, 0, 256]
+        )
+        hist = cv2.normalize(hist, hist).flatten()
+        return hist
+    elif cv_dict["feature_extraction_algorithm"] == "combined_features":
+        """
+        Color histograms: Capture the “what” (which colors are present).
+        Spatial features: Capture the “where” (location of non-zero/colorful regions).
+        Combined features: Enable the clustering algorithm to group images based on both criteria.
+        """
+        bins = cv_dict["combined_features_bins"]
+        thirds: int = 3
+        split_imgs = np.array_split(img, thirds, axis=0)
+        features = []
+        nonzero_counts = []
+        for part in split_imgs:
+            hist = cv2.calcHist(
+                [part], [0, 1, 2], None, [bins, bins, bins], [0, 180, 0, 256, 0, 256]
+            )
+            hist = cv2.normalize(hist, hist).flatten()
+            features.append(hist)
+            # Grayscale for non-zero detection
+            gray = cv2.cvtColor(part, cv2.COLOR_BGR2GRAY) if part.ndim == 3 else part
+            nonzero_counts.append(np.count_nonzero(gray))
+        return np.concatenate(features + [np.array(nonzero_counts, dtype=np.float32)])
+    elif cv_dict["feature_extraction_algorithm"] == "sector_slice":
+        if img.ndim == 3:  # Convert to grayscale if needed
+            img = img.max(axis=2)
+            H, W = img.shape
+            sector_slices = get_sector_slices(H, W)
+            features = []
+            for s in sector_slices:
+                sector = img[s[0], s[1]]
+                features.append(int(np.any(sector > 0)))
+            return np.array(features, dtype=np.uint8)  # shape: (15,)
+    else:
+        raise ValueError(
+            f"Invalid feature_extraction_algorithm={cv_dict['feature_extraction_algorithm']}"
+        )
+
+
+def get_sector_slices(img_h, img_w):
+    # Example: hardcoded values, adjust to your layout!
+    thirds = np.linspace(0, img_h, 4, dtype=int)
+    segment_h = img_h // 8
+    segment_w = img_w // 8
+    top_bound = segment_h
+    bottom_bound = img_h - segment_h
+    left_bound = segment_w
+    right_bound = img_w - segment_w
+    # IMPORTANT!
+    # These sector definitions are extremely rough and do not translate well amongst plot types
+    sector_defs = [
+        # (y_start, y_end, x_start, x_end)
+        ("title", 0, top_bound, 0, img_w),
+        ("plot", top_bound, bottom_bound, left_bound, right_bound),
+        ("y_axis", top_bound, bottom_bound, 0, left_bound),
+        ("x_axis", bottom_bound, img_h, left_bound, right_bound),
+        ("colorbar", 0, img_h, right_bound, img_w),
+    ]
+    slices = []
+    for i in range(3):  # For each plot
+        y0, _ = thirds[i], thirds[i + 1]
+        for _, rel_y0, rel_y1, x0, x1 in sector_defs:
+            sector_slice = (slice(y0 + rel_y0, y0 + rel_y1), slice(x0, x1))
+            slices.append(sector_slice)
+    return slices
+
+
+def group_diffs(
+    features: List[np.ndarray],
+    diff_image_paths: List[str],
+    diff_dir: str,
+    cv_dict: Dict[str, Any],
+):
+    clusters_subdir: str = os.path.join(diff_dir, "clusters")
+    os.makedirs(clusters_subdir)
+    features = preprocess_diffs(clusters_subdir, features, cv_dict)
+    labels: np.ndarray = run_cluster_algorithm(features, cv_dict)
+
+    # Group diff_image_paths by cluster label
+    clusters: Dict[str, List[str]] = {}
+    idx: int
+    cluster_name: str
+    for idx, cluster_name in enumerate(labels):
+        if cluster_name == -1:
+            # -1 is noise in DBSCAN; treat as its own group
+            cluster_name = "noise"
+        clusters.setdefault(cluster_name, []).append(diff_image_paths[idx])
+    if not clusters:
+        raise ValueError("Likely, no labels were produced by fit_predict")
+    for cluster_name in clusters:
+        cluster_file_path: str = os.path.join(
+            clusters_subdir, f"cluster_{cluster_name}.txt"
+        )
+        this_cluster_subdir: str = os.path.join(
+            clusters_subdir, f"dir_cluster_{cluster_name}"
+        )
+        os.makedirs(this_cluster_subdir)
+        with open(cluster_file_path, "w") as cluster_file:
+            # Write all the diffs that are part of this cluster.
+            for diff_image_path in clusters[cluster_name]:
+                diff_image_path_suffix = copy_to_cluster_subdir(
+                    diff_image_path, diff_dir, this_cluster_subdir
+                )
+                cluster_file.write(f"{diff_image_path_suffix}\n")
+
+                computed_actual_path = diff_image_path.replace(
+                    "_diff.png", "_actual.png"
+                )
+                copy_to_cluster_subdir(
+                    computed_actual_path, diff_dir, this_cluster_subdir
+                )
+
+                computed_expected_path = diff_image_path.replace(
+                    "_diff.png", "_expected.png"
+                )
+                copy_to_cluster_subdir(
+                    computed_expected_path, diff_dir, this_cluster_subdir
+                )
+
+
+def preprocess_diffs(
+    clusters_subdir: str, features: List[np.ndarray], cv_dict: Dict[str, Any]
+) -> List[np.ndarray]:
+    if cv_dict["scale_features"]:
+        scaler = StandardScaler()
+        features = scaler.fit_transform(features)
+    if cv_dict["reduce_dimensions"]:
+        pca = PCA(n_components=10)
+        features = pca.fit_transform(features)
+    if cv_dict["plot_features"]:
+        tsne = TSNE(n_components=2, random_state=42)
+        features_2d = tsne.fit_transform(features)
+        plt.figure(figsize=(8, 6))
+        plt.scatter(features_2d[:, 0], features_2d[:, 1], s=10)
+        plt.title("t-SNE projection of features")
+        plt.xlabel("Component 1")
+        plt.ylabel("Component 2")
+        plt.tight_layout()
+        file_path: str = os.path.join(clusters_subdir, "feature_space_tsne.png")
+        plt.savefig(file_path, dpi=150)  # Save to file
+        plt.close()  # Close the figure to free memory
+    return features
+
+
+def run_cluster_algorithm(
+    features: List[np.ndarray], cv_dict: Dict[str, Any]
+) -> np.ndarray:
+    labels: np.ndarray
+    n_clusters: int = cv_dict["n_clusters"]
+    if cv_dict["cluster_algorithm"] == "DBSCAN":
+        # features & diff_image_paths are parallel lists
+        feature_array = np.array(features)
+        # OpenBLAS Warning : Detect OpenMP Loop and this application may hang. Please rebuild the library with USE_OPENMP=1 option.
+        clustering = DBSCAN(
+            eps=cv_dict["eps"], min_samples=cv_dict["min_samples"], metric="euclidean"
+        )
+        labels = clustering.fit_predict(feature_array)
+    elif cv_dict["cluster_algorithm"] == "KMeans":
+        clustering = KMeans(n_clusters=min(n_clusters, len(features)), random_state=42)
+        labels = clustering.fit_predict(features)
+    elif cv_dict["cluster_algorithm"] == "AgglomerativeClustering":
+        clustering = AgglomerativeClustering(n_clusters=n_clusters)
+        labels = clustering.fit_predict(features)
+    else:
+        raise ValueError(f"Invalid cluster_algorithm={cv_dict['cluster_algorithm']}")
+    return labels
+
+
+def copy_to_cluster_subdir(full_path: str, diff_dir: str, clusters_subdir: str) -> str:
+    relevant_suffix: str = full_path.removeprefix(diff_dir)
+    # Flatten the path so that all images appear at the same level
+    flat_suffix: str = relevant_suffix.replace("/", ".")
+    if flat_suffix.startswith("."):
+        # If we don't do this, the file name will start with "." and won't show up with `ls`
+        flat_suffix = flat_suffix.removeprefix(".")
+    new_path: str = os.path.join(clusters_subdir, flat_suffix)
+    # print(f"Copying {full_path} to {new_path}")
+    shutil.copy(full_path, new_path)
+    return relevant_suffix
 
 
 if __name__ == "__main__":
     # Tries 1-2: with current image checker functions
-    # Try 3-: first attempt using cv2, Step 1: Compute Diff Images
-    cv_prototype(9)
+    # Tries 3-9: first attempt using cv2, compute_diff_image
+    # Tries 10-13: detect_features
+    # Tries 14-24: reworking code to group multiple diff images together
+    # Tries 25-28: working on clusters
+    # Tries 29-32: 4 combinations of DBSCAN/KMeans & extract features on diff/diff+actual
+    # Try 33: cleaned up code, DBSCAN & diff-only
+    # Try 34: cleaned up code, DBSCAN & diff+actual
+    # Tries 35-38: new feature detection, clustering algorithms
+    """
+    ###########################################################################
+    To run:
+    ```bash
+    # Initial setup
+    cd /home/ac.forsyth2/ez/zppy
+    lcrc_conda # alias to set up conda
+    pre-commit run --all-files
+    git add -A
+    conda clean --all --y
+    conda env create -f conda/dev.yml -n zppy-hackathon-20250707-with-cv
+    conda activate zppy-hackathon-20250707-with-cv
+    pip install .
+
+    # Each run
+    # Update `try_num` below (the argument to `cv_prototype`)
+    pre-commit run --all-files
+    git add -A
+    python tests/integration/image_checker.py
+    # Compare missing/mismatched images with the original image checker's results
+    # Change the number below to the `try_num`
+    ${num} = 0
+    diff /lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/cv_prototype/diff_try${num}/e3sm_diags/missing_images.txt /lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/cv_prototype/diff_try1/e3sm_diags/missing_images.txt
+    diff /lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/cv_prototype/diff_try${num}/e3sm_diags/mismatched_images.txt /lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/cv_prototype/diff_try1/e3sm_diags/mismatched_images.txt
+    ```
+
+    ###########################################################################
+    Try 29: feature detection -- actual + diffs, clustering algorithm -- DBSCAN
+    Total of 69 mismatched images. That's 12 more than the original image checker found,
+    because we're using a new mask-and-threshold method. Those new diffs are:
+    < lat_lon/Cloud SSM/I/SSMI-TGCLDLWP_OCN-ANN-global.png
+    < lat_lon/Cloud SSM/I/SSMI-TGCLDLWP_OCN-DJF-global.png
+    < lat_lon/Cloud SSM/I/SSMI-TGCLDLWP_OCN-JJA-global.png
+    < lat_lon/OMI-MLS/OMI-MLS-TCO-JJA-60S60N.png
+    < lat_lon/SST_CL_HadISST/HadISST_CL-SST-ANN-global.png
+    < lat_lon/SST_CL_HadISST/HadISST_CL-SST-DJF-global.png
+    < at_lon/SST_CL_HadISST/HadISST_CL-SST-JJA-global.png
+    < lat_lon/SST_CL_HadISST/HadISST_CL-SST-MAM-global.png
+    < lat_lon/SST_PD_HadISST/HadISST_PD-SST-ANN-global.png
+    < lat_lon/SST_PD_HadISST/HadISST_PD-SST-DJF-global.png
+    < lat_lon/SST_PD_HadISST/HadISST_PD-SST-MAM-global.png
+    < lat_lon/SST_PI_HadISST/HadISST_PI-SST-ANN-global.png
+
+    These 27 diffs all involve the bottom plot AND the metrics
+    0: 5 polar MERRA2 > MERRA2-U-850-{season}-polar_S, diffs in bottom plot/metrics
+    1: 7 polar MERRA2 > MERRA2-T-850-{season}-polar_{hemisphere}, diffs in bottom plot/metrics
+    2: 5 polar MERRA2 > MERRA2-U-850-{season}_polar_{hemisphere}, diffs in bottom plot/metrics
+    6: 5 lat_lon Cloud_Calpiso > CALIPSOCOSP-CLDLOW_CAL-{season}-global, diffs in bottom plot/metrics
+    11: 5 lat_lon MERRA2 > MERRA2-OMEGA-850-{season}-global, diffs in bottom plot/metrics
+
+    These 7 diffs all involve all 3 plots
+    3: 3 tropical_subseasonal wavernumber-frequency > PRECT_{}_15N-15S, diffs in all 3 plots
+    4: 4 tropical_subseasonal wavernumber-frequency > PRECT_norm_{}_15N-15S, diffs in all 3 plots
+
+    These 5 diffs all involve the bottom plot only
+    9: 5 lat_lon MERRA2 > MERRA2-U-850-{season}-global, all barely noticeable diffs in bottom plot
+
+    These 25 diffs all involve the bottom plots and/or metrics, but with less similarity
+    5: 15 lat_lon SST_{}_HadISST > HadISST_{}-SST-{season}-global diff always in bottom plot, sometimes on bottom metrics; some diffs are barely visible, but some are noticeable
+    7: 3 lat_lon OMI-MLS > OMI-MLS-TCO-{season}-60S60N, 1 barely noticeable diff in bottom plot, 1 diff in bottom plot/metrics, 1 diff in bottom plot only
+    8: 3 lat_lon Cloud_SSM.I > SSMI-TGCLDLWP_OCN-{season}-global, 2 nearly invisible diffs in bottom plot, 1 nearly invisible diff in bottom metrics
+    10: 4 lat_lon MERRA2 > MERRA2-T-850-{season}-global, 2 diffs in bottom plot/metrics and 2 just in bottom plot
+
+    noise: 5 remaining diffs. 1 lat_lon, 3 polar, 1 qbo
+
+    CONCLUSIONS
+    - Diffs of plots in the same family almost always have the same things wrong with them.
+    - Our combination of feature detection + clustering algorithm (DBSCAN) is actually able to tell which plot types are which, so that is interesting/good. HOWEVER, we're really more interested in grouping together similar diffs. E.g., clusters 0,1,2,6,11 above all involve diffs in the bottom plot AND metrics. Is there *anything* we can do to get the feature detection/clustering algorithm to merge clusters 0,1,2,6,11 into one cluster?
+    - The ultimate goal here is to be able to look at just a few representative diffs rather than needing to sort through many many diffs manually (69 diffs is already a lot, but there can be even more).
+
+    ###########################################################################
+    Try 30: feature detection -- diffs only, clustering algorithm -- DBSCAN
+
+    cluster_0 has all 69 diffs in it.
+
+    CONCLUSIONS
+    - Looking at only the diffs, it doesn't seem "smart" enough to distinguish that the 3-plot square diffs of tropical_subseasonal clearly belong in a different cluster than the small world map diffs of the other plots.
+
+    ###########################################################################
+    Try 31: feature detection -- diffs only, clustering algorithm -- KMeans
+
+    Trying with n_clusters = 3. Can we get it to make the following 3 clusters: the world map plots, the tropical_subseasonal plots, and the qbo plots?
+
+    Clusters:
+    0: 2 tropical_subseasonal diffs
+    2: 2 tropical_subseasonal diffs
+    1: the remaining 65 diffs, including 3 tropical_subseasonal diffs
+
+    CONCLUSIONS
+    - Not good at all. The tropical subeasonal plots are spread out into 3 clusters and everything else is in one of those.
+
+    ###########################################################################
+    Try 32: feature detection -- actual + diffs, clustering algorithm -- KMeans
+
+    Clusters:
+    0: 39 diffs in lat_lon, polar, tropical_subseasonal
+    1: 21 diffs in lat_lon, polar
+    2: 9 diffs in polar
+
+    ###########################################################################
+    Try 38: feature detection -- diffs, clustering algorithm -- AC
+    4 clusters -- 2 for tropical_subseasonal, 1 for qbo, and 1 for lat_lon/polar
+    Pretty decent!
+
+    ###########################################################################
+    Try 40: feature detection -- sector slice on diffs, clustering algorithm -- AC
+    3 clusters -- 2 for tropical_subseasonal/qbo, 1 for lat_lon, 1 for lat_lon/polar/tropical_subseasonal
+    So, not that great
+
+    diff_try# subdirectories to keep: 1, 2, 7, 9, 29, 30, 31, 32, 38
+    TODO: delete remaining try# subdirectories
+    """
+    cv_dict: Dict[str, Any] = {
+        # Image diff
+        "gray_diff_threshold": 30,  # Out of 255
+        # Feature extraction
+        "extract_diff_features_only": True,
+        "feature_extraction_algorithm": "sector_slice",
+        "simple_hist_bins": 32,
+        "combined_features_bins": 8,
+        # Preprocessing
+        "scale_features": True,
+        "reduce_dimensions": True,
+        "plot_features": True,
+        # Clustering
+        "cluster_algorithm": "AgglomerativeClustering",
+        # Clustering > DBSCAN
+        "eps": 0.5,
+        "min_samples": 2,
+        # Clustering > KMeans, AgglomerativeClustering
+        "n_clusters": 3,
+    }
+    cv_prototype(41, cv_dict)


### PR DESCRIPTION
# Hackathon project: Applying computer vision to image checking

This is a prototype and is not meant to be merged. The pull request is for easy visibility/ability to comment.

## Goal

The image checker can produce a great number of diffs. These are currenty organized by plot type. 

This poses a problem if many of the diffs are similar -- it's not a great use of a developer's time to manually look through say 1,000 diffs only to realize every single one is just "the pixels shifted slightly left" or "the colorbar changed so of course the plots look different".

What would be ideal is to use computer vision/machine learning to group those diffs how we want them. E.g., "every diff in `cluster_0/` is because the pixels shifted, every diff in `cluster_1/` is because its colorbar changed, and so on".

That would mean the developer only needs to look at a diff or two in each cluster to know what the issues are. There would be no need to manually review each diff, saving a lot of time.

## Setting up

<details>

<summary> setup </summary>

Set up the directories to test on:
```bash
# Set up actual_images_dir
cd /lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2
mkdir -p cv_prototype/actual_from_20250613/e3sm_diags/
cp -r zppy_weekly_comprehensive_v3_www/test_weekly_20250613/v3.LR.historical_0051/e3sm_diags/atm_monthly_180x360_aave cv_prototype/actual_from_20250613/e3sm_diags/
ls cv_prototype/actual_from_20250613/e3sm_diags/atm_monthly_180x360_aave/model_vs_obs_1987-1988/
# Contains the different sets, good

# Set up expected_images_dir
cd /lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2
mkdir -p cv_prototype/expected_from_unified/e3sm_diags/
cp -r /lcrc/group/e3sm/public_html/zppy_test_resources_previous/expected_results_for_unified_1.11.1/expected_comprehensive_v3/e3sm_diags/atm_monthly_180x360_aave cv_prototype/expected_from_unified/e3sm_diags/
ls cv_prototype/expected_from_unified/e3sm_diags/atm_monthly_180x360_aave/model_vs_obs_1987-1988/
# Contains the different sets, good

# Get the list of files we expect, expected_images_list
cd cv_prototype/expected_from_unified/
find . -type f -name '*.png' > ../image_list_expected.txt
cd ..
ls
# actual_from_20250613  expected_from_unified  image_list_expected.txt
```

To run:
```bash
# Initial setup
cd /home/ac.forsyth2/ez/zppy
lcrc_conda # alias to set up conda
pre-commit run --all-files
git add -A
conda clean --all --y
conda env create -f conda/dev.yml -n zppy-hackathon-20250707-with-cv
conda activate zppy-hackathon-20250707-with-cv
pip install .

# Each run
# Update `try_num` below (the argument to `cv_prototype`)
pre-commit run --all-files
git add -A
python tests/integration/image_checker.py
# Compare missing/mismatched images with the original image checker's results
# Change the number below to the `try_num`
${num} = 0
diff /lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/cv_prototype/diff_try${num}/e3sm_diags/missing_images.txt /lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/cv_prototype/diff_try1/e3sm_diags/missing_images.txt
diff /lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/cv_prototype/diff_try${num}/e3sm_diags/mismatched_images.txt /lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/cv_prototype/diff_try1/e3sm_diags/mismatched_images.txt
```
</details>

## Explaining the code

The `cv_prototype` function effectively replaces `set_up_and_run_image_checker` as the caller of `check_images`. If this was _actually_ at the point of merging, we'd change
```python
test_results = check_images(parameters, task)
```
in `set_up_and_run_image_checker` to:
```python
test_results = check_images(parameters, task, cv_dict=cv_dict)
```
where `cv_dict` is defined as something like what we have in the `main` block now. With that change, the integration test suite could make use of this code. This `cv_dict` allows us to configure the pipeline with modularity. We can easily swap out different feature extraction, preprocessing, and clustering algorithms.

The `check_images` function is more-or-less unchanged, except for passing along `cv_dict`.

The `_check_mismatched_images` function has 2 important additions, if we're in CV mode (i.e., `cv_dict` is non-empty)
1. For each file, call `_cv_compare_actual_and_expected`, which is in fact substantially different than its counterpart `_compare_actual_and_expected`.
2. After going through all the files, call `group_diffs`.

Let's dive into `_cv_compare_actual_and_expected`:
1. `get_images`: we now use `cv2.imread` instead of `Image.open`
2. `compute_diff_image`: before, we filtered based on `if fraction >= 0.0002`. That is, the fraction of mismatched pixels needed to be less than 0.02%. This is a little different. Here, we're seeing how high the grayscale value is for each pixel in the diff. If it's > `gray_diff_threshold`, we add it to the mask.
3. `write_images`: more-or-less the same as what we were doing in `compare_actual_and_expected`, but using `cv2.imwrite` and no longer drawing bounding boxes on the diffs. (I assume this is possible, but the cv2 images are `ndarray`s not `Image`s, so I didn't look into translating over the bounding box drawing.)
4. `update_features`: this is totally new. This is finding the important features in the diffs. I.e., it's finding _what_ to cluster the diffs (or, optionally, the actuals + the diffs) on. This currently has 3 options we can swap out: "simple_hist" is just a normalized color histogram, "combined_features" adds in spatial features, "sector_slice" is an attempt to slice up the image into relevant pieces.

And dive into `group_diffs`:
1. `preprocess_diffs`: preprocess the features, as needed. We have options to scale features, reduce dimensions, and plot the features for a visual analysis.
2. `run_cluster_algorithm`: run a clustering algorithm. There are options for DBSCAN, KMeans, and AgglomerativeClustering.
3. Go through the clusters and copy over actual/expected/diff images to a subdirectory for each cluster.

## Results

- Using `compute_diff_image` with a `gray_diff_threshold` of `30` results in 12 more mismatches (57 => 69).
- For feature extraction algorithm, "combined_features" seems to give the best results.
- For clustering algorithm, AgglomerativeClustering seems to give the best results.

I ran quite a few iterations of the code, tracked with the `try_num`. The results can be seen in the `diff_try#` subdirectories of [this page](https://web.lcrc.anl.gov/public/e3sm/diagnostic_output/ac.forsyth2/cv_prototype/important_tries/)

<details>

<summary> Interesting iterations </summary>

```
Try 2: original image checker

Try 9: using `cv2` for diff computation. Adds 12 mismatches (57 => 59):
lat_lon/Cloud SSM/I/SSMI-TGCLDLWP_OCN-ANN-global.png
lat_lon/Cloud SSM/I/SSMI-TGCLDLWP_OCN-DJF-global.png
lat_lon/Cloud SSM/I/SSMI-TGCLDLWP_OCN-JJA-global.png
lat_lon/OMI-MLS/OMI-MLS-TCO-JJA-60S60N.png
lat_lon/SST_CL_HadISST/HadISST_CL-SST-ANN-global.png
lat_lon/SST_CL_HadISST/HadISST_CL-SST-DJF-global.png
lat_lon/SST_CL_HadISST/HadISST_CL-SST-JJA-global.png
lat_lon/SST_CL_HadISST/HadISST_CL-SST-MAM-global.png
lat_lon/SST_PD_HadISST/HadISST_PD-SST-ANN-global.png
lat_lon/SST_PD_HadISST/HadISST_PD-SST-DJF-global.png
lat_lon/SST_PD_HadISST/HadISST_PD-SST-MAM-global.png
lat_lon/SST_PI_HadISST/HadISST_PI-SST-ANN-global.png

Tries 29-32: combinations of detecting features on <diff only, actual + diff> and clustering using <DBSCAN, KMeans>

###############################################################################
Try 29: feature detection -- actual + diffs, clustering algorithm -- DBSCAN
Total of 69 mismatched images.

These 27 diffs all involve the bottom plot AND the metrics
0: 5 polar MERRA2 > MERRA2-U-850-{season}-polar_S, diffs in bottom plot/metrics
1: 7 polar MERRA2 > MERRA2-T-850-{season}-polar_{hemisphere}, diffs in bottom plot/metrics
2: 5 polar MERRA2 > MERRA2-U-850-{season}_polar_{hemisphere}, diffs in bottom plot/metrics
6: 5 lat_lon Cloud_Calpiso > CALIPSOCOSP-CLDLOW_CAL-{season}-global, diffs in bottom plot/metrics
11: 5 lat_lon MERRA2 > MERRA2-OMEGA-850-{season}-global, diffs in bottom plot/metrics

These 7 diffs all involve all 3 plots
3: 3 tropical_subseasonal wavernumber-frequency > PRECT_{}_15N-15S, diffs in all 3 plots
4: 4 tropical_subseasonal wavernumber-frequency > PRECT_norm_{}_15N-15S, diffs in all 3 plots

These 5 diffs all involve the bottom plot only
9: 5 lat_lon MERRA2 > MERRA2-U-850-{season}-global, all barely noticeable diffs in bottom plot

These 25 diffs all involve the bottom plots and/or metrics, but with less similarity
5: 15 lat_lon SST_{}_HadISST > HadISST_{}-SST-{season}-global diff always in bottom plot, sometimes on bottom metrics; some diffs are barely visible, but some are noticeable
7: 3 lat_lon OMI-MLS > OMI-MLS-TCO-{season}-60S60N, 1 barely noticeable diff in bottom plot, 1 diff in bottom plot/metrics, 1 diff in bottom plot only
8: 3 lat_lon Cloud_SSM.I > SSMI-TGCLDLWP_OCN-{season}-global, 2 nearly invisible diffs in bottom plot, 1 nearly invisible diff in bottom metrics
10: 4 lat_lon MERRA2 > MERRA2-T-850-{season}-global, 2 diffs in bottom plot/metrics and 2 just in bottom plot

noise: 5 remaining diffs. 1 lat_lon, 3 polar, 1 qbo

CONCLUSIONS
- Diffs of plots in the same family almost always have the same things wrong with them.
- Our combination of feature detection + clustering algorithm (DBSCAN) is actually able to tell which plot types are which, so that is interesting/good. HOWEVER, we're really more interested in grouping together similar diffs. E.g., clusters 0,1,2,6,11 above all involve diffs in the bottom plot AND metrics. Is there *anything* we can do to get the feature detection/clustering algorithm to merge clusters 0,1,2,6,11 into one cluster?
- The ultimate goal here is to be able to look at just a few representative diffs rather than needing to sort through many many diffs manually (69 diffs is already a lot, but there can be even more).

###########################################################################
Try 30: feature detection -- diffs only, clustering algorithm -- DBSCAN

cluster_0 has all 69 diffs in it.

CONCLUSIONS
- Looking at only the diffs, it doesn't seem "smart" enough to distinguish that the 3-plot square diffs of tropical_subseasonal clearly belong in a different cluster than the small world map diffs of the other plots.

###########################################################################
Try 31: feature detection -- diffs only, clustering algorithm -- KMeans

Trying with n_clusters = 3. Can we get it to make the following 3 clusters: the world map plots, the tropical_subseasonal plots, and the qbo plots?

Clusters:
0: 2 tropical_subseasonal diffs
2: 2 tropical_subseasonal diffs
1: the remaining 65 diffs, including 3 tropical_subseasonal diffs

CONCLUSIONS
- Not good at all. The tropical subeasonal plots are spread out into 3 clusters and everything else is in one of those.

###########################################################################
Try 32: feature detection -- actual + diffs, clustering algorithm -- KMeans

Clusters:
0: 39 diffs in lat_lon, polar, tropical_subseasonal
1: 21 diffs in lat_lon, polar
2: 9 diffs in polar

###########################################################################
Now, we turn to AgglomerativeClustering

###########################################################################
Try 38: feature detection -- diffs, clustering algorithm -- AC
4 clusters -- 2 for tropical_subseasonal, 1 for qbo, and 1 for lat_lon/polar
Pretty decent!

###########################################################################
Try 40: feature detection -- sector slice on diffs, clustering algorithm -- AC
3 clusters -- 2 for tropical_subseasonal/qbo, 1 for lat_lon, 1 for lat_lon/polar/tropical_subseasonal
So, not that great
```

```
Full iteration summary:
Tries 1-2: with original image checker functions
Tries 3-9: first attempt using cv2, compute_diff_image
Tries 10-13: detect_features
Tries 14-24: reworking code to group multiple diff images together
Tries 25-28: working on clusters
Tries 29-32: 4 combinations of DBSCAN/KMeans & extract features on diff/diff+actual
Try 33: cleaned up code, DBSCAN & diff-only
Try 34: cleaned up code, DBSCAN & diff+actual
Tries 35-38: new feature detection, clustering algorithms
Tries 38-40: trying sector slice for feature detection
Tries 41-42: code cleanup
```

Directories were moved as follows:
```bash
cd /lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/cv_prototype
mkdir important_tries
mv diff_try2 important_tries/diff_try2
mv diff_try9 important_tries/diff_try9
mv diff_try29 important_tries/diff_try29
mv diff_try30 important_tries/diff_try30
mv diff_try31 important_tries/diff_try31
mv diff_try32 important_tries/diff_try32
mv diff_try38 important_tries/diff_try38
mv diff_try40 important_tries/diff_try40

mkdir less_important_tries
mv diff_try1 less_important_tries/diff_try1
mv diff_try41 important_tries/diff_try41

mkdir other_tries
mv diff_try* other_tries/
du -sh other_tries/
# 2.4G	other_tries/
# These can probably be deleted
```

</details>

## Best Result

The combination of parameters in this PR are what have given the best result so far:
```python
cv_dict: Dict[str, Any] = {
    # Image diff
    "gray_diff_threshold": 30,  # Out of 255
    # Feature extraction
    "extract_diff_features_only": True,
    "feature_extraction_algorithm": "combined_features",
    "simple_hist_bins": 32,
    "combined_features_bins": 8,
    # Preprocessing
    "scale_features": True,
    "reduce_dimensions": True,
    "plot_features": True,
    # Clustering
    "cluster_algorithm": "AgglomerativeClustering",
    # Clustering > DBSCAN
    "eps": 0.5,
    "min_samples": 2,
    # Clustering > KMeans, AgglomerativeClustering
    "n_clusters": 4,
}
```
Notably:
```
"feature_extraction_algorithm": "combined_features"
"cluster_algorithm": "AgglomerativeClustering"
"n_clusters": 4
```
That produces these 4 clusters:
```
0: tropical_subseasonal diffs that look almost like terrain maps
1: tropical subseasonal diffs that look like waves
2: the qbo diff
3: all the lat_lon/polar diffs
```

These results can be seen [here](https://web.lcrc.anl.gov/public/e3sm/diagnostic_output/ac.forsyth2/cv_prototype/diff_try42/clusters).

## Leveraging LivChat

LivChat was very useful in suggesting code snippets. It helped substantially in narrowing down areas to debug. For example, asked "is this issue because of the feature extraction or the clustering algorithm?" it explained how it was almost certainly the feature extraction that was the problem. It also suggested alternative clustering algorithms.

## What would be needed to merge?

- Find some way of getting the diffs to group based on _what_ is different. It seems they're more grouped by the plot type at the moment. 
  - We'd need a bigger test set. E.g., get some diffs where some lat_lon plots have different titles but others have an axis label change, where some have the diffs in the top plot but others have the diffs in the bottom plot.
- As mentioned above, in `set_up_and_run_image_checker` set:
```python
test_results = check_images(parameters, task, cv_dict=cv_dict)
```