### PR TITLE
fix e3sm_diags year looping for land model vs model

### DIFF
--- a/zppy/e3sm_diags.py
+++ b/zppy/e3sm_diags.py
@@ -44,8 +44,8 @@ def e3sm_diags(config: ConfigObj, script_dir: str, existing_bundles, job_ids_fil
         ref_year_sets: List[Tuple[int, int]]
         if ("ref_years" in c.keys()) and (c["ref_years"] != [""]):
             ref_year_sets = get_years(c["ref_years"])
-            # For model_vs_model, use the single reference year set for all test year sets
-            if c["run_type"] == "model_vs_model" and len(ref_year_sets) == 1:
+            # If there is a single reference period provided, replicate it for all test year sets
+            if len(ref_year_sets) == 1:
                 ref_year_sets = ref_year_sets * len(year_sets)
         else:
             ref_year_sets = year_sets


### PR DESCRIPTION
## Summary
The original design assumption was that ref_years and years would have the same number
  of year sets, creating 1:1 pairings:
  - Test period 1 vs Reference period 1
  - Test period 2 vs Reference period 2
  - etc.

 One of the common use cases include single reference : ref_years = "451-500" with multiple test periods. This fix handles this common us case while keep the original design.


Select one: This pull request is...
- [x] a bug fix: increment the patch version
- [ ] a small improvement: increment the minor version
- [ ] a new feature: increment the minor version
- [ ] an incompatible (non-backwards compatible) API change: increment the major version

## Small Change

- [ ] To merge, I will use "Squash and merge". That is, this change should be a single commit.
- [ ] Logic: I have visually inspected the entire pull request myself.
- [ ] Pre-commit checks: All the pre-commits checks have passed.
