### PR TITLE
Remove meta references

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,6 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
-        exclude: conda/meta.yaml
 
   # Can run individually with `pre-commit run black --all-files`
   - repo: https://github.com/psf/black

--- a/tbump.toml
+++ b/tbump.toml
@@ -28,9 +28,6 @@ src = "pyproject.toml"
 [[file]]
 src = "zppy/__init__.py"
 
-[[file]]
-src = "conda/meta.yaml"
-
 # You can specify a list of commands to
 # run after the files have been patched
 # and before the git commit is made


### PR DESCRIPTION
## Summary

Objectives:
- Remove references to `conda/meta.yaml`. This is a follow-up fix to #744. When we removed that file, we should have also removed where it was referenced, as we did in `zstash` with https://github.com/E3SM-Project/zstash/pull/390.

Select one: This pull request is...
- [x] a bug fix: increment the patch version
- [ ] a small improvement: increment the minor version
- [ ] a new feature: increment the minor version
- [ ] an incompatible (non-backwards compatible) API change: increment the major version

Please fill out either the "Small Change" or "Big Change" section (the latter includes the numbered subsections), and delete the other.

## Small Change

- [x] To merge, I will use "Squash and merge". That is, this change should be a single commit.
- [x] Logic: I have visually inspected the entire pull request myself.
- [x] Pre-commit checks: All the pre-commits checks have passed.