### PR TITLE
Add Python 3.14 support

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -37,10 +37,10 @@ jobs:
       - name: Checkout Code Repository
         uses: actions/checkout@v3
 
-      - name: Set up Python 3.13
+      - name: Set up Python 3.14
         uses: actions/setup-python@v4
         with:
-          python-version: 3.13
+          python-version: 3.14
 
       # Run all pre-commit hooks on all the files.
       # Getting only staged files can be tricky in case a new PR is opened
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     defaults:
       run:
         shell: bash -l {0}
@@ -92,7 +92,7 @@ jobs:
           # Ensure we have the right Python version
           python --version
           # Fix pip issues for Python 3.12+
-          if [[ "${{ matrix.python-version }}" == "3.12" ]] || [[ "${{ matrix.python-version }}" == "3.13" ]]; then
+          if [[ "${{ matrix.python-version }}" == "3.12" ]] || [[ "${{ matrix.python-version }}" == "3.13" ]] || [[ "${{ matrix.python-version }}" == "3.14" ]]; then
             python -m ensurepip --upgrade || true
             python -m pip install --upgrade --force-reinstall pip setuptools wheel
           fi
@@ -144,7 +144,7 @@ jobs:
           environment-file: conda/dev.yml
           channel-priority: flexible # Changed from strict to flexible
           auto-update-conda: true
-          python-version: "3.13" # Use stable Python version for docs
+          python-version: "3.14" # Use stable Python version for docs
 
       - if: ${{ needs.check-jobs-to-skip.outputs.should_skip != 'true' }}
         name: Show Conda Environment Info

--- a/conda/dev.yml
+++ b/conda/dev.yml
@@ -10,7 +10,7 @@ channels:
 dependencies:
   # Build
   # =======================
-  - python >=3.11,<3.14
+  - python >=3.11,<3.15
   - pip
   # Base
   # =================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ name = "zppy"
 version = "3.1.0rc3"
 description = "Post-processing software for E3SM"
 readme = "README.md"
-requires-python = ">=3.11,<3.14"
+requires-python = ">=3.11,<3.15"
 license = { file = "LICENSE" }
 authors = [
   { name = "Ryan Forsyth", email = "forsyth2@llnl.gov" },
@@ -30,6 +30,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Scientific/Engineering",
 ]
 
@@ -96,7 +97,7 @@ exclude = [
 ]
 
 [tool.mypy]
-python_version = "3.13"
+python_version = "3.14"
 check_untyped_defs = true
 ignore_missing_imports = true
 warn_unused_ignores = true


### PR DESCRIPTION
## Summary

Important: this should be merged to `main` _after_ the production release of `zppy v3.1.0`.

Objectives:
- Add support for Python 3.14

Issue resolution:
- Equivalent of https://github.com/E3SM-Project/zppy-interfaces/pull/44, https://github.com/E3SM-Project/zstash/pull/402

Select one: This pull request is...
- [ ] a bug fix: increment the patch version
- [x] a small improvement: increment the minor version
- [ ] a new feature: increment the minor version
- [ ] an incompatible (non-backwards compatible) API change: increment the major version

## Small Change

- [x] To merge, I will use "Squash and merge". That is, this change should be a single commit.
- [x] Logic: I have visually inspected the entire pull request myself.
- [x] Pre-commit checks: All the pre-commits checks have passed.