### PR TITLE
Add additional files to the mpas-analysis cache for time series analysis

### DIFF
--- a/zppy/templates/mpas_analysis.bash
+++ b/zppy/templates/mpas_analysis.bash
@@ -40,11 +40,6 @@ mkdir -p ${identifier}
 mkdir -p cfg
 
 {% if cache == true %}
-files=( "mpasIndexOcean.nc" "mpasTimeSeriesOcean.nc" "seaIceAreaVolNH.nc" "seaIceAreaVolSH.nc")
-for file in "${files[@]}"
-do
-  cp cache/timeseries/${file} ${identifier}/timeseries/${file}
-done
 # Restore cached copies of pre-computed files
 cached=( "timeseries/moc" "timeseries/OceanBasins" "timeseries/transport" )
 mkdir -p cache
@@ -52,6 +47,11 @@ for subdir in "${cached[@]}"
 do
   mkdir -p cache/${subdir} ${identifier}/${subdir}
   rsync -av cache/${subdir}/ ${identifier}/${subdir}/
+done
+files=( "mpasIndexOcean.nc" "mpasTimeSeriesOcean.nc" "seaIceAreaVolNH.nc" "seaIceAreaVolSH.nc")
+for file in "${files[@]}"
+do
+  cp cache/timeseries/${file} ${identifier}/timeseries/${file}
 done
 {% endif %}
 


### PR DESCRIPTION
## Summary

Objectives:
- Cache additional MPAS-Analysis files needed to extend time series plots from existing analysis when the source files are not present in the output path (typically because they have been long-term archived)
- Remove an MPAS-Analysis file that may be large (with `nCells` dimensions) when MPAS-Analysis has been completed which is not needed to extend time series plots

Select one: This pull request is...
- [ ] a bug fix: increment the patch version
- [X] a small improvement: increment the minor version
- [ ] a new feature: increment the minor version
- [ ] an incompatible (non-backwards compatible) API change: increment the major version

## Small Change

- [X] To merge, I will use "Squash and merge". That is, this change should be a single commit.
- [X] Logic: I have visually inspected the entire pull request myself.
- [X] Pre-commit checks: All the pre-commits checks have passed.