### PR TITLE
Allow tests to use different `mpas_analysis` environment

### DIFF
--- a/tests/integration/generated/test_weekly_comprehensive_v2_chrysalis.cfg
+++ b/tests/integration/generated/test_weekly_comprehensive_v2_chrysalis.cfg
@@ -170,6 +170,7 @@ active = True
 anomalyRefYear = 1980
 climo_years ="1980-1984", "1985-1990",
 enso_years = "1980-1984", "1985-1990",
+environment_commands = "source <INSERT PATH TO CONDA>/conda.sh; conda activate <INSERT ENV NAME>"
 mesh = "EC30to60E2r2"
 parallelTaskCount = 6
 partition = "compute"

--- a/tests/integration/generated/test_weekly_comprehensive_v3_chrysalis.cfg
+++ b/tests/integration/generated/test_weekly_comprehensive_v3_chrysalis.cfg
@@ -203,6 +203,7 @@ active = True
 anomalyRefYear = 1985
 climo_years = "1985-1989", "1990-1995",
 enso_years = "1985-1989", "1990-1995",
+environment_commands = "source <INSERT PATH TO CONDA>/conda.sh; conda activate <INSERT ENV NAME>"
 mesh = "IcoswISC30E3r5"
 parallelTaskCount = 6
 partition = "compute"

--- a/tests/integration/generated/test_weekly_legacy_3.0.0_comprehensive_v2_chrysalis.cfg
+++ b/tests/integration/generated/test_weekly_legacy_3.0.0_comprehensive_v2_chrysalis.cfg
@@ -170,6 +170,7 @@ active = True
 anomalyRefYear = 1980
 climo_years ="1980-1984", "1985-1990",
 enso_years = "1980-1984", "1985-1990",
+environment_commands = "source <INSERT PATH TO CONDA>/conda.sh; conda activate <INSERT ENV NAME>"
 mesh = "EC30to60E2r2"
 parallelTaskCount = 6
 partition = "compute"

--- a/tests/integration/generated/test_weekly_legacy_3.0.0_comprehensive_v3_chrysalis.cfg
+++ b/tests/integration/generated/test_weekly_legacy_3.0.0_comprehensive_v3_chrysalis.cfg
@@ -204,6 +204,7 @@ active = True
 anomalyRefYear = 1985
 climo_years = "1985-1989", "1990-1995",
 enso_years = "1985-1989", "1990-1995",
+environment_commands = "source <INSERT PATH TO CONDA>/conda.sh; conda activate <INSERT ENV NAME>"
 mesh = "IcoswISC30E3r5"
 parallelTaskCount = 6
 partition = "compute"

--- a/tests/integration/template_weekly_comprehensive_v2.cfg
+++ b/tests/integration/template_weekly_comprehensive_v2.cfg
@@ -170,6 +170,7 @@ active = #expand active_mpas_analysis#
 anomalyRefYear = 1980
 climo_years ="1980-1984", "1985-1990",
 enso_years = "1980-1984", "1985-1990",
+environment_commands = "#expand mpas_analysis_environment_commands#"
 mesh = "EC30to60E2r2"
 parallelTaskCount = 6
 partition = "#expand partition_long#"

--- a/tests/integration/template_weekly_comprehensive_v3.cfg
+++ b/tests/integration/template_weekly_comprehensive_v3.cfg
@@ -203,6 +203,7 @@ active = #expand active_mpas_analysis#
 anomalyRefYear = 1985
 climo_years = "1985-1989", "1990-1995",
 enso_years = "1985-1989", "1990-1995",
+environment_commands = "#expand mpas_analysis_environment_commands#"
 mesh = "IcoswISC30E3r5"
 parallelTaskCount = 6
 partition = "#expand partition_long#"

--- a/tests/integration/template_weekly_legacy_3.0.0_comprehensive_v2.cfg
+++ b/tests/integration/template_weekly_legacy_3.0.0_comprehensive_v2.cfg
@@ -170,6 +170,7 @@ active = #expand active_mpas_analysis#
 anomalyRefYear = 1980
 climo_years ="1980-1984", "1985-1990",
 enso_years = "1980-1984", "1985-1990",
+environment_commands = "#expand mpas_analysis_environment_commands#"
 mesh = "EC30to60E2r2"
 parallelTaskCount = 6
 partition = "#expand partition_long#"

--- a/tests/integration/template_weekly_legacy_3.0.0_comprehensive_v3.cfg
+++ b/tests/integration/template_weekly_legacy_3.0.0_comprehensive_v3.cfg
@@ -204,6 +204,7 @@ active = #expand active_mpas_analysis#
 anomalyRefYear = 1985
 climo_years = "1985-1989", "1990-1995",
 enso_years = "1985-1989", "1990-1995",
+environment_commands = "#expand mpas_analysis_environment_commands#"
 mesh = "IcoswISC30E3r5"
 parallelTaskCount = 6
 partition = "#expand partition_long#"

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -20,6 +20,7 @@ TEST_SPECIFICS: Dict[str, Any] = {
     # (`environment_commands = ""` only redirects to Unified
     # if specified under the [default] task)
     "diags_environment_commands": "source <INSERT PATH TO CONDA>/conda.sh; conda activate <INSERT ENV NAME>",
+    "mpas_analysis_environment_commands": "source <INSERT PATH TO CONDA>/conda.sh; conda activate <INSERT ENV NAME>",
     "global_time_series_environment_commands": "source <INSERT PATH TO CONDA>/conda.sh; conda activate <INSERT ENV NAME>",
     "pcmdi_diags_environment_commands": "source <INSERT PATH TO CONDA>/conda.sh; conda activate <INSERT ENV NAME>",
     # This is the environment setup for other tasks.
@@ -142,6 +143,9 @@ def get_expansions():
     # Set up environments
     expansions["diags_environment_commands"] = TEST_SPECIFICS[
         "diags_environment_commands"
+    ]
+    expansions["mpas_analysis_environment_commands"] = TEST_SPECIFICS[
+        "mpas_analysis_environment_commands"
     ]
     expansions["global_time_series_environment_commands"] = TEST_SPECIFICS[
         "global_time_series_environment_commands"
@@ -305,6 +309,9 @@ def generate_cfgs(dry_run=False):
     print("CFG FILES HAVE BEEN GENERATED FROM TEMPLATES WITH THESE SETTINGS:")
     print(f"UNIQUE_ID={TEST_SPECIFICS['unique_id']}")
     print(f"diags_environment_commands={expansions['diags_environment_commands']}")
+    print(
+        f"mpas_analysis_environment_commands={expansions['mpas_analysis_environment_commands']}"
+    )
     print(
         f"global_time_series_environment_commands={expansions['global_time_series_environment_commands']}"
     )


### PR DESCRIPTION
## Summary

Objectives:
- Add the ability to specify `environment_commands` for `mpas_analysis` in testing. (Note this was always possible as a user: just set `environment_commands` in the cfg).

Issue resolution:
- Allows for testing of #760.

Select one: This pull request is...
- [ ] a bug fix: increment the patch version
- [x] a small improvement: increment the minor version
- [ ] a new feature: increment the minor version
- [ ] an incompatible (non-backwards compatible) API change: increment the major version

## Small Change

- [ ] To merge, I will use "Squash and merge". That is, this change should be a single commit.
- [ ] Logic: I have visually inspected the entire pull request myself.
- [ ] Pre-commit checks: All the pre-commits checks have passed.