### PR TITLE
Fix legacy 3.1.0 www paths

### DIFF
--- a/tests/integration/generated/test_weekly_legacy_3.1.0_bundles_chrysalis.cfg
+++ b/tests/integration/generated/test_weekly_legacy_3.1.0_bundles_chrysalis.cfg
@@ -36,7 +36,7 @@ output = "/lcrc/group/e3sm/ac.forsyth2/zppy_weekly_legacy_3.1.0_bundles_output/u
 partition = "compute"
 qos = "regular"
 walltime = "07:00:00"
-www = "/lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_weekly_bundles_www/unique_id"
+www = "/lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_weekly_legacy_3.1.0_bundles_www/unique_id"
 
 [bundle]
 

--- a/tests/integration/generated/test_weekly_legacy_3.1.0_comprehensive_v2_chrysalis.cfg
+++ b/tests/integration/generated/test_weekly_legacy_3.1.0_comprehensive_v2_chrysalis.cfg
@@ -10,7 +10,7 @@ mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
 output = "/lcrc/group/e3sm/ac.forsyth2/zppy_weekly_legacy_3.1.0_comprehensive_v2_output/unique_id/v2.LR.historical_0201"
 partition = "debug"
 qos = "regular"
-www = "/lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_weekly_comprehensive_v2_www/unique_id"
+www = "/lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_weekly_legacy_3.1.0_comprehensive_v2_www/unique_id"
 years = "1980:1984:2",
 
 [climo]

--- a/tests/integration/generated/test_weekly_legacy_3.1.0_comprehensive_v3_chrysalis.cfg
+++ b/tests/integration/generated/test_weekly_legacy_3.1.0_comprehensive_v3_chrysalis.cfg
@@ -12,7 +12,7 @@ mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
 output = "/lcrc/group/e3sm/ac.forsyth2/zppy_weekly_legacy_3.1.0_comprehensive_v3_output/unique_id/v3.LR.historical_0051"
 partition = "debug"
 qos = "regular"
-www = "/lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_weekly_comprehensive_v3_www/unique_id"
+www = "/lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_weekly_legacy_3.1.0_comprehensive_v3_www/unique_id"
 years = "1985:1989:2",
 
 [climo]

--- a/tests/integration/template_weekly_legacy_3.1.0_bundles.cfg
+++ b/tests/integration/template_weekly_legacy_3.1.0_bundles.cfg
@@ -36,7 +36,7 @@ output = "#expand user_output#zppy_weekly_legacy_3.1.0_bundles_output/#expand un
 partition = "#expand partition_long#"
 qos = "#expand qos_short#"
 walltime = "#expand bundles_walltime#"
-www = "#expand user_www#zppy_weekly_bundles_www/#expand unique_id#"
+www = "#expand user_www#zppy_weekly_legacy_3.1.0_bundles_www/#expand unique_id#"
 
 [bundle]
 

--- a/tests/integration/template_weekly_legacy_3.1.0_comprehensive_v2.cfg
+++ b/tests/integration/template_weekly_legacy_3.1.0_comprehensive_v2.cfg
@@ -10,7 +10,7 @@ mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
 output = "#expand user_output#zppy_weekly_legacy_3.1.0_comprehensive_v2_output/#expand unique_id#/#expand case_name_v2#"
 partition = "#expand partition_short#"
 qos = "#expand qos_short#"
-www = "#expand user_www#zppy_weekly_comprehensive_v2_www/#expand unique_id#"
+www = "#expand user_www#zppy_weekly_legacy_3.1.0_comprehensive_v2_www/#expand unique_id#"
 years = "1980:1984:2",
 
 [climo]

--- a/tests/integration/template_weekly_legacy_3.1.0_comprehensive_v3.cfg
+++ b/tests/integration/template_weekly_legacy_3.1.0_comprehensive_v3.cfg
@@ -12,7 +12,7 @@ mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
 output = "#expand user_output#zppy_weekly_legacy_3.1.0_comprehensive_v3_output/#expand unique_id#/#expand case_name#"
 partition = "#expand partition_short#"
 qos = "#expand qos_short#"
-www = "#expand user_www#zppy_weekly_comprehensive_v3_www/#expand unique_id#"
+www = "#expand user_www#zppy_weekly_legacy_3.1.0_comprehensive_v3_www/#expand unique_id#"
 years = "1985:1989:2",
 
 [climo]


### PR DESCRIPTION
## Summary

Objectives:
- Fix the `www` path for the legacy-3.1.0 tests to avoid over-writing of results from the non-legacy tests.

Issue resolution:
- Resolves issue noted in [3/25 main branch test](https://github.com/E3SM-Project/zppy/discussions/634#discussioncomment-16335384)

Select one: This pull request is...
- [x] a bug fix: increment the patch version
- [ ] a small improvement: increment the minor version
- [ ] a new feature: increment the minor version
- [ ] an incompatible (non-backwards compatible) API change: increment the major version

## Small Change

- [x] To merge, I will use "Squash and merge". That is, this change should be a single commit.
- [x] Logic: I have visually inspected the entire pull request myself.
- [x] Pre-commit checks: All the pre-commits checks have passed.