### PR TITLE
Bug fix for livvkit climo_subsection issue

### DIFF
--- a/zppy/livvkit.py
+++ b/zppy/livvkit.py
@@ -131,7 +131,7 @@ def determine_and_add_dependencies(
     )
 
     climo_subsections: List[str] = []
-    if "climo_subsections" in _c.keys():
+    if ("climo_subsections" in _c.keys()) and _c["climo_subsections"]:
         climo_subsections = _c["climo_subsections"]
     elif ("infer_section_parameters" in _c.keys()) and _c["infer_section_parameters"]:
         grids = ["_native"]


### PR DESCRIPTION
In default.ini `climo_subsections = string_list(default=list(""))`, so if this parameter is not defined in the input configuration, the climo_subsections parameter exists, but is empty and the subsections are not inferred.

## Summary

Objectives:
- Fix subsection inference bug

Select one: This pull request is...
- [x] a bug fix: increment the patch version
- [ ] a small improvement: increment the minor version
- [ ] a new feature: increment the minor version
- [ ] an incompatible (non-backwards compatible) API change: increment the major version

Please fill out either the "Small Change" or "Big Change" section (the latter includes the numbered subsections), and delete the other.

## Small Change

- [x] To merge, I will use "Squash and merge". That is, this change should be a single commit.
- [x] Logic: I have visually inspected the entire pull request myself.
- [x] Pre-commit checks: All the pre-commits checks have passed.