### PR TITLE
Fixes of unified rc4 and rc5

### DIFF
--- a/tests/integration/generated/directions_pm-cpu.md
+++ b/tests/integration/generated/directions_pm-cpu.md
@@ -1,0 +1,93 @@
+# Testing directions for pm-cpu
+
+## How to run a cfg
+
+```
+# Change UNIQUE_ID in tests/integration/utils.py
+#
+$ pip install . && python tests/integration/utils.py
+```
+
+Now, if you're running the e3sm_diags task,
+it's a good idea to test on the latest diags code.
+(If you're not, then skip to the next code block).
+```
+# `cd` to e3sm_diags directory
+$ git checkout main
+$ git fetch upstream
+$ git reset --hard upstream/main
+$ git log # Should match https://github.com/E3SM-Project/e3sm_diags/commits/main
+$ mamba clean --all
+$ mamba env create -f conda-env/dev.yml -n e3sm_diags_<date>
+$ conda activate e3sm_diags_<date>
+$ pip install .
+$ `cd` back to zppy directory
+# Then edit tests/integration/utils.py `diags_environment_commands` to use that environment.
+```
+
+```
+$ zppy -c tests/integration/generated/test_<cfg-name>_pm-cpu.cfg
+# Some cfg files should be run twice (bundles)
+# Some cfg files are meant to be run after another (run mvm_2 after mvm_1 completes)
+$ cd /global/cfs/cdirs/e3sm/forsyth/zppy_test_<cfg-name>_output/<UNIQUE_ID>/v3.LR.historical_0051/post/scripts
+$ grep -v "OK" *status
+# If this has no output, that means there are no errors.
+```
+
+Changing `UNIQUE_ID` allows you to simultaneously run jobs
+launched from `zppy` on different branches,
+without worrying about overwriting results.
+
+NOTE: Actually running the tests (e.g., `pytest tests/integration/test_*.py`)
+can not be done from two different branches simultaneously
+(since files in the `zppy` directory rather than an external directory get changed).
+
+## Minimal cases
+
+Some tests specifically check minimal zppy cfgs:
+i.e., cfgs with as few parameters as possible to test a specific case.
+If your code changes could interact with these minimal cases,
+then you should run the relevant ones to make sure they still work.
+
+These do not have automatic Python testing.
+The comprehensive and bundles tests do have this, however.
+These tests are ideally run weekly on the `main` branch.
+
+## Commands to run to replace outdated expected files
+
+
+Basic tests:
+```
+cd <top level of zppy repo>
+
+chmod u+x tests/integration/generated/update_bash_generation_expected_files_pm-cpu.sh
+./tests/integration/generated/update_bash_generation_expected_files_pm-cpu.sh
+
+chmod u+x tests/integration/generated/update_campaign_expected_files_pm-cpu.sh
+./tests/integration/generated/update_campaign_expected_files_pm-cpu.sh
+# This command also runs the test again.
+# If the test fails on `test_campaign_high_res_v1`, try running the lines of the loop manually:
+rm -rf /global/cfs/cdirs/e3sm/www/zppy_test_resources/test_campaign_high_res_v1_expected_files
+mkdir -p /global/cfs/cdirs/e3sm/www/zppy_test_resources/test_campaign_high_res_v1_expected_files
+mv test_campaign_high_res_v1_output/post/scripts/*.settings /global/cfs/cdirs/e3sm/www/zppy_test_resources/test_campaign_high_res_v1_expected_files
+
+chmod u+x tests/integration/generated/update_defaults_expected_files_pm-cpu.sh
+./tests/integration/generated/update_defaults_expected_files_pm-cpu.sh
+```
+
+Weekly tests require running zppy beforehand:
+```
+cd <top level of zppy repo>
+chmod u+x tests/integration/generated/update_weekly_expected_files_pm-cpu.sh
+./tests/integration/generated/update_weekly_expected_files_pm-cpu.sh
+```
+
+## Commands to generate official expected results for a zppy/Unified release
+
+Edit `release_name` in
+`tests/integration/generated/update_archive_expected_files_pm-cpu.sh`.
+Then, run:
+```
+chmod u+x tests/integration/generated/update_archive_expected_files_pm-cpu.sh
+./tests/integration/generated/update_archive_expected_files_pm-cpu.sh
+```

--- a/tests/integration/generated/test_weekly_bundles_pm-cpu.cfg
+++ b/tests/integration/generated/test_weekly_bundles_pm-cpu.cfg
@@ -1,0 +1,171 @@
+# Test bundles.
+# Run this cfg twice.
+# Wait for the first run to finish before running again.
+#
+# 1st run of this cfg:
+# bundle 1:
+#   climo > atm_monthly_180x360_aave
+#         > atm_monthly_diurnal_8xdaily_180x360_aave
+#   ts > atm_monthly_180x360_aave
+#      > land_monthly
+#   e3sm_to_cmip > atm_monthly_180x360_aave
+#                > land_monthly
+#   e3sm_diags > atm_monthly_180x360_aave
+# bundle 2:
+#   ts > atm_monthly_glb
+#   global_time_series
+#
+# 2nd run of this cfg:
+# bundle 3:
+#   ts > rof_monthly
+#   tc_analysis
+#   e3sm_diags > atm_monthly_180x360_aave_mvm
+# no bundle:
+#   ilamb
+
+[default]
+case = "v3.LR.historical_0051"
+constraint = "cpu"
+dry_run = "False"
+environment_commands = ""
+input = /global/cfs/cdirs/e3sm/forsyth//E3SMv3/v3.LR.historical_0051
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+# To run this test, edit `output` and `www` in this file, along with `actual_images_dir` in test_bundles.py
+output = "/global/cfs/cdirs/e3sm/forsyth/zppy_weekly_bundles_output/unique_id/v3.LR.historical_0051"
+partition = ""
+qos = "regular"
+walltime = "6:00:00"
+www = "/global/cfs/cdirs/e3sm/www/forsyth/zppy_weekly_bundles_www/unique_id"
+
+[bundle]
+
+  [[ bundle2 ]]
+  nodes = 2
+  walltime = "00:59:00"
+
+[climo]
+active = True
+bundle = "bundle1"
+years = "1985:1989:2",
+
+  [[ atm_monthly_180x360_aave ]]
+  frequency = "monthly"
+
+  [[ atm_monthly_diurnal_8xdaily_180x360_aave ]]
+  active = True
+  frequency = "diurnal_8xdaily"
+  input_files = "eam.h3"
+  input_subdir = "archive/atm/hist"
+  vars = "PRECT"
+
+[ts]
+active = True
+bundle = "bundle1"
+years = "1985:1989:2",
+
+  [[ atm_monthly_180x360_aave ]]
+  frequency = "monthly"
+  input_files = "eam.h0"
+  input_subdir = "archive/atm/hist"
+
+  [[ atm_monthly_glb ]]
+  active = True
+  bundle = "bundle2" # Override bundle1
+  frequency = "monthly"
+  input_files = "eam.h0"
+  input_subdir = "archive/atm/hist"
+  mapping_file = "glb"
+  years = "1985:1995:5",
+
+  [[ land_monthly ]]
+  extra_vars = "landfrac"
+  frequency = "monthly"
+  input_files = "elm.h0"
+  input_subdir = "archive/lnd/hist"
+  mapping_file = "map_r05_to_cmip6_180x360_aave.20231110.nc"
+  vars = "LAISHA,LAISUN"
+
+  [[ rof_monthly ]]
+  active = True
+  bundle = "bundle3" # Override bundle1, let bundle1 finish first because "e3sm_diags: atm_monthly_180x360_aave_mvm" requires "ts: atm_monthly_180x360_aave"
+  extra_vars = 'areatotal2'
+  frequency = "monthly"
+  input_files = "mosart.h0"
+  input_subdir = "archive/rof/hist"
+  mapping_file = ""
+  vars = "RIVER_DISCHARGE_OVER_LAND_LIQ"
+
+[e3sm_to_cmip]
+active = True
+bundle = "bundle1"
+frequency = "monthly"
+ts_num_years = 2
+years = "1985:1989:2",
+
+  [[ atm_monthly_180x360_aave ]]
+  input_files = "eam.h0"
+
+  [[ land_monthly ]]
+  input_files = "elm.h0"
+
+# TODO: Add "tc_analysis" back in after empty dat is resolved.
+# [tc_analysis]
+# active = True
+# bundle = "bundle3" # Let bundle1 finish first because "e3sm_diags: atm_monthly_180x360_aave_mvm" requires "ts: atm_monthly_180x360_aave"
+# years = "1985:1989:2",
+
+[e3sm_diags]
+active = True
+environment_commands = "source <INSERT PATH TO CONDA>/conda.sh; conda activate <INSERT ENV NAME>"
+grid = '180x360_aave'
+ref_final_yr = 1989
+ref_start_yr = 1985
+short_name = "v3.LR.historical_0051"
+ts_num_years = 2
+years = "1985:1989:2",
+
+  [[ atm_monthly_180x360_aave ]]
+  bundle = "bundle1"
+  climo_diurnal_frequency = "diurnal_8xdaily"
+  climo_diurnal_subsection = "atm_monthly_diurnal_8xdaily_180x360_aave"
+  sets = "polar","enso_diags","diurnal_cycle",
+
+  [[ atm_monthly_180x360_aave_mvm ]]
+  # Test model-vs-model using the same files as the reference
+  bundle = "bundle3"
+  climo_subsection = "atm_monthly_180x360_aave"
+  diff_title = "Difference"
+  ref_final_yr = 1986
+  ref_name = "v3.LR.historical_0051"
+  ref_start_yr = 1985
+  ref_years = "1985-1986",
+  reference_data_path = "/global/cfs/cdirs/e3sm/forsyth/zppy_weekly_bundles_output/unique_id/v3.LR.historical_0051/post/atm/180x360_aave/clim"
+  run_type = "model_vs_model"
+  # TODO: Add "tc_analysis" back in after empty dat is resolved.
+  sets = "polar","enso_diags","streamflow",
+  short_ref_name = "v3.LR.historical_0051"
+  swap_test_ref = False
+  tag = "model_vs_model"
+  ts_num_years_ref = 2
+  ts_subsection = "atm_monthly_180x360_aave"
+  years = "1987-1988"
+
+[global_time_series]
+active = True
+bundle = "bundle2"
+environment_commands = "source <INSERT PATH TO CONDA>/conda.sh; conda activate <INSERT ENV NAME>"
+experiment_name = "v3.LR.historical_0051"
+figstr = "v3.LR.historical_0051"
+plots_original="net_toa_flux_restom,global_surface_air_temperature,toa_radiation,net_atm_energy_imbalance,net_atm_water_imbalance"
+ts_num_years = 5
+walltime = "00:30:00" # bundle2 should take walltime from "ts: atm_monthly_glb", i.e., "02:00:00"
+years = "1985-1995",
+
+[ilamb]
+active = True
+# No bundle, let bundle1 finish first because "ilamb" requires "ts: atm_monthly_180x360_aave" and "ts: land_monthly"
+grid = '180x360_aave'
+short_name = "v3.LR.historical_0051"
+ts_num_years = 2
+years = "1985:1987:2",

--- a/tests/integration/generated/test_weekly_bundles_pm-cpu.cfg
+++ b/tests/integration/generated/test_weekly_bundles_pm-cpu.cfg
@@ -99,6 +99,7 @@ years = "1985:1989:2",
 [e3sm_to_cmip]
 active = True
 bundle = "bundle1"
+environment_commands = "source <INSERT PATH TO CONDA>/conda.sh; conda activate <INSERT ENV NAME>"
 frequency = "monthly"
 ts_num_years = 2
 years = "1985:1989:2",

--- a/tests/integration/generated/test_weekly_comprehensive_v2_pm-cpu.cfg
+++ b/tests/integration/generated/test_weekly_comprehensive_v2_pm-cpu.cfg
@@ -1,0 +1,202 @@
+[default]
+case = "v2.LR.historical_0201"
+constraint = "cpu"
+dry_run = "False"
+environment_commands = ""
+fail_on_dependency_skip = True
+input = /global/cfs/cdirs/e3sm/forsyth//E3SMv2/v2.LR.historical_0201
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "/global/cfs/cdirs/e3sm/forsyth/zppy_weekly_comprehensive_v2_output/unique_id/v2.LR.historical_0201"
+partition = ""
+qos = "regular"
+www = "/global/cfs/cdirs/e3sm/www/forsyth/zppy_weekly_comprehensive_v2_www/unique_id"
+years = "1980:1984:2",
+
+[climo]
+active = True
+walltime = "00:30:00"
+
+  [[ atm_monthly_180x360_aave ]]
+  frequency = "monthly"
+  input_files = "eam.h0"
+  input_subdir = "archive/atm/hist"
+  vars = ""
+
+  [[ atm_monthly_diurnal_8xdaily_180x360_aave ]]
+  active = True
+  frequency = "diurnal_8xdaily"
+  input_files = "eam.h3"
+  input_subdir = "archive/atm/hist"
+  vars = "PRECT"
+
+  [[ land_monthly_climo ]]
+  active = True
+  frequency = "monthly"
+  input_files = "elm.h0"
+  input_subdir = "archive/lnd/hist"
+  vars = ""
+
+[ts]
+active = True
+walltime = "00:30:00"
+
+  [[ atm_monthly_180x360_aave ]]
+  frequency = "monthly"
+  input_files = "eam.h0"
+  input_subdir = "archive/atm/hist"
+
+  [[ atm_daily_180x360_aave ]]
+  active = True
+  frequency = "daily"
+  input_files = "eam.h1"
+  input_subdir = "archive/atm/hist"
+  vars = "PRECT"
+
+  [[ rof_monthly ]]
+  active = True
+  extra_vars = 'areatotal2'
+  frequency = "monthly"
+  input_files = "mosart.h0"
+  input_subdir = "archive/rof/hist"
+  mapping_file = ""
+  vars = "RIVER_DISCHARGE_OVER_LAND_LIQ"
+
+  [[ atm_monthly_glb ]]
+  # Note global average won't work for 3D variables.
+  active = True
+  frequency = "monthly"
+  input_files = "eam.h0"
+  input_subdir = "archive/atm/hist"
+  mapping_file = "glb"
+  years = "1980:1990:5",
+
+  [[ lnd_monthly_glb ]]
+  active = True
+  frequency = "monthly"
+  input_files = "elm.h0"
+  input_subdir = "archive/lnd/hist"
+  mapping_file = "glb"
+  vars = "LAISHA,LAISUN"
+  years = "1980:1990:5",
+
+  [[ land_monthly ]]
+  extra_vars = "landfrac"
+  frequency = "monthly"
+  input_files = "elm.h0"
+  input_subdir = "archive/lnd/hist"
+  vars = "LAISHA,LAISUN"
+
+[e3sm_to_cmip]
+active = True
+frequency = "monthly"
+ts_num_years=2
+walltime = "00:30:00"
+
+  [[ atm_monthly_180x360_aave ]]
+  input_files = "eam.h0"
+
+  [[ land_monthly ]]
+  input_files = "elm.h0"
+
+[tc_analysis]
+active = True
+walltime = "00:30:00"
+
+[e3sm_diags]
+active = True
+climo_diurnal_frequency = "diurnal_8xdaily"
+climo_diurnal_subsection = "atm_monthly_diurnal_8xdaily_180x360_aave"
+environment_commands = "source <INSERT PATH TO CONDA>/conda.sh; conda activate <INSERT ENV NAME>"
+grid = '180x360_aave'
+multiprocessing = True
+num_workers = 8
+partition = ""
+qos = "regular"
+ref_final_yr = 1981
+ref_start_yr = 1980
+ref_years = "1980-1981",
+# Include all sets
+# min_case_e3sm_diags_depend_on_climo: "lat_lon","zonal_mean_xy","zonal_mean_2d","polar","cosp_histogram","meridional_mean_2d","annual_cycle_zonal_mean","zonal_mean_2d_stratosphere","aerosol_aeronet","aerosol_budget",
+# min_case_e3sm_diags_depend_on_ts: "enso_diags","qbo",
+# min_case_e3sm_diags_diurnal_cycle: "diurnal_cycle",
+# min_case_e3sm_diags_streamflow: "streamflow",
+# min_case_e3sm_diags_tc_analysis: "tc_analysis",
+# min_case_e3sm_diags_tropical_subseasonal: "tropical_subseasonal",
+sets = "lat_lon","zonal_mean_xy","zonal_mean_2d","polar","cosp_histogram","meridional_mean_2d","annual_cycle_zonal_mean","zonal_mean_2d_stratosphere","enso_diags","qbo","diurnal_cycle","streamflow","tc_analysis","tropical_subseasonal","aerosol_aeronet","aerosol_budget",
+short_name = "v2.LR.historical_0201"
+ts_num_years = 2
+walltime = "6:00:00"
+years = "1982:1984:2",
+
+  [[ atm_monthly_180x360_aave ]]
+  climo_subsection = "atm_monthly_180x360_aave"
+  dc_obs_climo = '/global/cfs/cdirs/e3sm/diagnostics/observations/Atm/climatology/'
+
+  [[ atm_monthly_180x360_aave_mvm ]]
+  # Test model-vs-model using the same files as the reference
+  climo_subsection = "atm_monthly_180x360_aave"
+  diff_title = "Difference"
+  partition = ""
+  qos = "regular"
+  ref_name = "v2.LR.historical_0201"
+  reference_data_path = "/global/cfs/cdirs/e3sm/forsyth/zppy_weekly_comprehensive_v2_output/unique_id/v2.LR.historical_0201/post/atm/180x360_aave/clim"
+  run_type = "model_vs_model"
+  short_ref_name = "same simulation"
+  swap_test_ref = False
+  tag = "model_vs_model"
+  ts_daily_subsection = "atm_monthly_180x360_aave"
+  ts_num_years_ref = 2
+  ts_subsection = "atm_monthly_180x360_aave"
+  years = "1980:1982:2",
+
+  [[ lnd_monthly_mvm_lnd ]]
+  # Test model-vs-model using the same files as the reference
+  climo_subsection = "land_monthly_climo"
+  diff_title = "Difference"
+  partition = ""
+  qos = "regular"
+  ref_name = "v2.LR.historical_0201"
+  reference_data_path = "/global/cfs/cdirs/e3sm/forsyth/zppy_weekly_comprehensive_v2_output/unique_id/v2.LR.historical_0201/post/lnd/180x360_aave/clim"
+  run_type = "model_vs_model"
+  sets = "lat_lon_land",
+  short_ref_name = "same simulation"
+  swap_test_ref = False
+  tag = "model_vs_model"
+  ts_num_years_ref = 2
+
+[mpas_analysis]
+active = True
+anomalyRefYear = 1980
+climo_years ="1980-1984", "1985-1990",
+enso_years = "1980-1984", "1985-1990",
+environment_commands = "source <INSERT PATH TO CONDA>/conda.sh; conda activate <INSERT ENV NAME>"
+mesh = "EC30to60E2r2"
+parallelTaskCount = 6
+partition = ""
+qos = "regular"
+shortTermArchive = True
+ts_years = "1980-1984", "1980-1990",
+walltime = "03:00:00"
+
+[global_time_series]
+active = True
+climo_years ="1980-1984", "1985-1990",
+environment_commands = "source <INSERT PATH TO CONDA>/conda.sh; conda activate <INSERT ENV NAME>"
+experiment_name = "v2.LR.historical_0201"
+figstr = "v2.LR.historical_0201"
+moc_file=mocTimeSeries_1980-1990.nc
+plots_lnd = "LAISHA,LAISUN"
+ts_num_years = 5
+ts_years = "1980-1984", "1980-1990",
+walltime = "00:30:00"
+years = "1980-1990",
+
+[ilamb]
+active = True
+nodes = 8
+partition = ""
+short_name = "v2.LR.historical_0201"
+ts_num_years = 2
+walltime = "2:00:00"
+years = "1980:1984:2",

--- a/tests/integration/generated/test_weekly_comprehensive_v2_pm-cpu.cfg
+++ b/tests/integration/generated/test_weekly_comprehensive_v2_pm-cpu.cfg
@@ -89,6 +89,7 @@ walltime = "00:30:00"
 
 [e3sm_to_cmip]
 active = True
+environment_commands = "source <INSERT PATH TO CONDA>/conda.sh; conda activate <INSERT ENV NAME>"
 frequency = "monthly"
 ts_num_years=2
 walltime = "00:30:00"

--- a/tests/integration/generated/test_weekly_comprehensive_v3_pm-cpu.cfg
+++ b/tests/integration/generated/test_weekly_comprehensive_v3_pm-cpu.cfg
@@ -182,7 +182,7 @@ walltime = "00:30:00"
 
   [[ atm_monthly_180x360_aave ]]
   cmip_plevdata = "/global/cfs/cdirs/e3sm/diagnostics/e3sm_to_cmip_data/maps/vrt_remap_plev19.nc"
-  cmip_vars = "ua, va, ta, wa, zg, hur, tas, ts, psl, ps, sfcWind, huss, pr, prc, prsn, evspsbl, tauu, tauv, hfls, clt, rlus, rsds, rsus, hfss, clivi, clwvi, rlut, rsdt, rsuscs, rsut, rtmt, abs550aer, od550aer, rsdscs, tasmax, tasmin"
+  cmip_vars = "ua, va, ta, wap, zg, hur, tas, ts, psl, ps, sfcWind, huss, pr, prc, prsn, evspsbl, tauu, tauv, hfls, clt, rlus, rsds, rsus, hfss, clivi, clwvi, rlut, rsdt, rsuscs, rsut, rtmt, abs550aer, od550aer, rsdscs, tasmax, tasmin"
   input_files = "eam.h0"
   ts_subsection = "atm_monthly_180x360_aave"
   vars = "ICEFRAC,LANDFRAC,OCNFRAC,PSL,FSNTC,FSNTOAC,SWCF,LWCF,FLUT,FSNT,FSNTOA,FLNT,FLNTC,FSNS,FLNS,FSNS,SHFLX,QFLX,LHFLX,TAUX,TAUY,PRECC,PRECL,PRECSC,PRECSL,TS,TREFHT,U10,QREFHT,TMQ,CLDTOT,CLDHGH,CLDMED,CLDLOW,FLDS,FSDS,TGCLDIWP,TGCLDCWP,TGCLDLWP,FLNSC,FLUTC,FSDSC,SOLIN,FSNSC,AODABS,AODVIS,AODDUST,AREL,TREFMNAV,TREFMXAV,PS,PHIS,U,V,T,Z3"

--- a/tests/integration/generated/test_weekly_comprehensive_v3_pm-cpu.cfg
+++ b/tests/integration/generated/test_weekly_comprehensive_v3_pm-cpu.cfg
@@ -176,6 +176,7 @@ walltime = "00:30:00"
 
 [e3sm_to_cmip]
 active = True
+environment_commands = "source <INSERT PATH TO CONDA>/conda.sh; conda activate <INSERT ENV NAME>"
 frequency = "monthly"
 ts_num_years=2
 walltime = "00:30:00"

--- a/tests/integration/generated/test_weekly_comprehensive_v3_pm-cpu.cfg
+++ b/tests/integration/generated/test_weekly_comprehensive_v3_pm-cpu.cfg
@@ -1,18 +1,18 @@
 [default]
-case = "#expand case_name#"
-constraint = "#expand constraint#"
-dry_run = "#expand dry_run#"
-environment_commands = "#expand environment_commands#"
+case = "v3.LR.historical_0051"
+constraint = "cpu"
+dry_run = "False"
+environment_commands = ""
 fail_on_dependency_skip = True
 infer_path_parameters = False
 infer_section_parameters = False
-input = #expand user_input_v3#/E3SMv3/#expand case_name#
+input = /global/cfs/cdirs/e3sm/forsyth//E3SMv3/v3.LR.historical_0051
 input_subdir = archive/atm/hist
 mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
-output = "#expand user_output#zppy_weekly_comprehensive_v3_output/#expand unique_id#/#expand case_name#"
-partition = "#expand partition_short#"
-qos = "#expand qos_short#"
-www = "#expand user_www#zppy_weekly_comprehensive_v3_www/#expand unique_id#"
+output = "/global/cfs/cdirs/e3sm/forsyth/zppy_weekly_comprehensive_v3_output/unique_id/v3.LR.historical_0051"
+partition = ""
+qos = "regular"
+www = "/global/cfs/cdirs/e3sm/www/forsyth/zppy_weekly_comprehensive_v3_www/unique_id"
 years = "1985:1989:2",
 
 [climo]
@@ -26,7 +26,7 @@ walltime = "00:30:00"
   vars = ""
 
   [[ atm_monthly_diurnal_8xdaily_180x360_aave ]]
-  active = #expand active_e3sm_diags#
+  active = True
   frequency = "diurnal_8xdaily"
   input_files = "eam.h3"
   input_subdir = "archive/atm/hist"
@@ -40,15 +40,15 @@ walltime = "00:30:00"
   vars = ""
 
   [[ land_monthly_180x360_traave ]]
-   active = #expand active_livvkit#
+   active = True
   input_files = "elm.h0"
   input_subdir = "archive/lnd/hist"
-  mapping_file = "#expand livvkit_mapping_file_path_alternative#/map_r05_to_cmip6_180x360_traave.20240901.nc"
+  mapping_file = "/global/cfs/cdirs/e3sm/diagnostics/maps/map_r05_to_cmip6_180x360_traave.20240901.nc"
   vars = ""
   years = "1985:1994:10",
 
   [[ land_monthly_climo_native ]]
-  active = #expand active_livvkit#
+  active = True
   climo_jobs = 12
   input_files = "elm.h0"
   input_subdir = "archive/lnd/hist"
@@ -57,46 +57,46 @@ walltime = "00:30:00"
   years = "1985:1994:10"
 
   [[ land_monthly_climo_racmo_gis ]]
-  active = #expand active_livvkit#
+  active = True
   climo_jobs = 12
   climo_subsection = "racmo_gis"
   grid = "racmo_gis"
   input_files = "elm.h0"
   input_subdir = "archive/lnd/hist"
-  mapping_file = "#expand livvkit_mapping_file_path_alternative#/map_r05_to_racmo_gis_566x438_traave.20240801.nc"
+  mapping_file = "/global/cfs/cdirs/e3sm/diagnostics/maps/map_r05_to_racmo_gis_566x438_traave.20240801.nc"
   vars = ""
   years = "1985:1994:10"
 
   [[ land_monthly_climo_racmo_ais ]]
-  active = #expand active_livvkit#
+  active = True
   climo_jobs = 12
   input_files = "elm.h0"
   climo_subsection = "racmo_ais"
   grid = "racmo_ais"
   input_subdir = "archive/lnd/hist"
-  mapping_file = "#expand livvkit_mapping_file_path#/map_r05_to_racmo_ais_591x726.nc"
+  mapping_file = "/global/cfs/cdirs/e3sm/diagnostics/maps/map_r05_to_racmo_ais_591x726.nc"
   vars = ""
   years = "1985:1994:10"
 
   [[ land_monthly_climo_merra2 ]]
-  active = #expand active_livvkit#
+  active = True
   climo_jobs = 12
   input_files = "elm.h0"
   climo_subsection = "merra2"
   grid = "merra2"
   input_subdir = "archive/lnd/hist"
-  mapping_file = "#expand livvkit_mapping_file_path#/map_r05_to_merra2_traave.20250124.nc"
+  mapping_file = "/global/cfs/cdirs/e3sm/diagnostics/maps/map_r05_to_merra2_traave.20250124.nc"
   vars = ""
   years = "1985:1994:10"
 
   [[ land_monthly_climo_era5 ]]
-  active = #expand active_livvkit#
+  active = True
   climo_jobs = 12
   input_files = "elm.h0"
   climo_subsection = "era5"
   grid = "era5"
   input_subdir = "archive/lnd/hist"
-  mapping_file = "#expand livvkit_mapping_file_path#/map_r05_to_era5_s2n_721x1440.traave.20240124.nc"
+  mapping_file = "/global/cfs/cdirs/e3sm/diagnostics/maps/map_r05_to_era5_s2n_721x1440.traave.20240124.nc"
   vars = ""
   years = "1985:1994:10"
 
@@ -114,14 +114,14 @@ walltime = "00:30:00"
   vars = "FSNTOA,FLUT,FSNT,FLNT,FSNS,FLNS,SHFLX,QFLX,TAUX,TAUY,PRECC,PRECL,PRECSC,PRECSL,TS,TREFHT,CLDTOT,CLDHGH,CLDMED,CLDLOW,U,PSL,LANDFRAC,CLD_CAL_TMPICE,CLD_CAL_TMPLIQ,CLDLIQ,T"
 
   [[ atm_daily_180x360_aave ]]
-  active = #expand active_e3sm_diags#
+  active = True
   frequency = "daily"
   input_files = "eam.h1"
   input_subdir = "archive/atm/hist"
   vars = "PRECT"
 
   [[ rof_monthly ]]
-  active = #expand active_e3sm_diags#
+  active = True
   extra_vars = 'areatotal2'
   frequency = "monthly"
   input_files = "mosart.h0"
@@ -131,7 +131,7 @@ walltime = "00:30:00"
 
   [[ atm_monthly_glb ]]
   # Note global average won't work for 3D variables.
-  active = #expand active_global_time_series#
+  active = True
   frequency = "monthly"
   input_files = "eam.h0"
   input_subdir = "archive/atm/hist"
@@ -139,7 +139,7 @@ walltime = "00:30:00"
   years = "1985:1995:5",
 
   [[ lnd_monthly_glb ]]
-  active = #expand active_global_time_series#
+  active = True
   frequency = "monthly"
   input_files = "elm.h0"
   input_subdir = "archive/lnd/hist"
@@ -156,7 +156,7 @@ walltime = "00:30:00"
   vars = "FSH,RH2M,LAISHA,LAISUN,QINTR,QOVER,QRUNOFF,QSOIL,QVEGE,QVEGT,SOILICE,SOILLIQ,SOILWATER_10CM,TSA,TSOI,H2OSNO,TOTLITC,CWDC,SOIL1C,SOIL2C,SOIL3C,SOIL4C,WOOD_HARVESTC,TOTVEGC,NBP,GPP,AR,HR"
 
   [[ land_monthly_energy ]]
-  active = #expand active_livvkit#
+  active = True
   frequency = "monthly"
   input_files = "elm.h0"
   input_subdir = "archive/lnd/hist"
@@ -175,13 +175,13 @@ walltime = "00:30:00"
   years = "1985:1994:10"
 
 [e3sm_to_cmip]
-active = #expand active_e3sm_to_cmip#
+active = True
 frequency = "monthly"
 ts_num_years=2
 walltime = "00:30:00"
 
   [[ atm_monthly_180x360_aave ]]
-  cmip_plevdata = "#expand diagnostics_base_path#/e3sm_to_cmip_data/maps/vrt_remap_plev19.nc"
+  cmip_plevdata = "/global/cfs/cdirs/e3sm/diagnostics/e3sm_to_cmip_data/maps/vrt_remap_plev19.nc"
   cmip_vars = "ua, va, ta, wa, zg, hur, tas, ts, psl, ps, sfcWind, huss, pr, prc, prsn, evspsbl, tauu, tauv, hfls, clt, rlus, rsds, rsus, hfss, clivi, clwvi, rlut, rsdt, rsuscs, rsut, rtmt, abs550aer, od550aer, rsdscs, tasmax, tasmin"
   input_files = "eam.h0"
   ts_subsection = "atm_monthly_180x360_aave"
@@ -198,16 +198,16 @@ walltime = "00:30:00"
 # walltime = "00:30:00"
 
 [e3sm_diags]
-active = #expand active_e3sm_diags#
+active = True
 climo_diurnal_frequency = "diurnal_8xdaily"
 climo_diurnal_subsection = "atm_monthly_diurnal_8xdaily_180x360_aave"
 climo_subsection = "atm_monthly_180x360_aave"
-environment_commands = "#expand diags_environment_commands#"
+environment_commands = "source <INSERT PATH TO CONDA>/conda.sh; conda activate <INSERT ENV NAME>"
 grid = '180x360_aave'
 multiprocessing = True
 num_workers = 8
-partition = "#expand partition_long#"
-qos = "#expand qos_long#"
+partition = ""
+qos = "regular"
 ref_final_yr = 1986
 ref_start_yr = 1985
 ref_years = "1985-1986",
@@ -221,57 +221,57 @@ ref_years = "1985-1986",
 # TODO: Add "tc_analysis" back in after empty dat is resolved.
 # TODO: Add "aerosol_budget" back in once that's working for v3.
 sets = "lat_lon","zonal_mean_xy","zonal_mean_2d","polar","cosp_histogram","meridional_mean_2d","annual_cycle_zonal_mean","zonal_mean_2d_stratosphere","enso_diags","qbo","diurnal_cycle","streamflow","tropical_subseasonal","aerosol_aeronet",
-short_name = "#expand case_name#"
+short_name = "v3.LR.historical_0051"
 ts_daily_subsection = "atm_daily_180x360_aave"
 ts_num_years = 2
 ts_subsection = "atm_monthly_180x360_aave"
-walltime = "#expand diags_walltime#"
+walltime = "6:00:00"
 years = "1987:1989:2"
 # Reference paths
 # Used for mvo and mvm, if ts_num_years is set
-obs_ts = "#expand diagnostics_base_path#/observations/Atm/time-series/"
+obs_ts = "/global/cfs/cdirs/e3sm/diagnostics/observations/Atm/time-series/"
 # mvo & mvm tc_analysis only
-tc_obs = "#expand diagnostics_base_path#/observations/Atm/tc-analysis/"
+tc_obs = "/global/cfs/cdirs/e3sm/diagnostics/observations/Atm/tc-analysis/"
 
   [[ atm_monthly_180x360_aave ]]
   # Reference paths
-  reference_data_path = "#expand diagnostics_base_path#/observations/Atm/climatology/"
+  reference_data_path = "/global/cfs/cdirs/e3sm/diagnostics/observations/Atm/climatology/"
   # mvo diurnal_cycle only
-  dc_obs_climo = '#expand path_dc_obs_climo#'
+  dc_obs_climo = '/global/cfs/cdirs/e3sm/diagnostics/observations/Atm/climatology/'
   # mvo streamflow only
-  streamflow_obs_ts = "#expand diagnostics_base_path#/observations/Atm/time-series/"
+  streamflow_obs_ts = "/global/cfs/cdirs/e3sm/diagnostics/observations/Atm/time-series/"
   sets = "lat_lon","zonal_mean_xy","zonal_mean_2d","polar","cosp_histogram","meridional_mean_2d","annual_cycle_zonal_mean","zonal_mean_2d_stratosphere","enso_diags","qbo","diurnal_cycle","streamflow","mp_partition","tropical_subseasonal","precip_pdf","aerosol_aeronet",
 
   [[ atm_monthly_180x360_aave_mvm ]]
   # Test model-vs-model using the same files as the reference
   diff_title = "Difference"
-  partition = "#expand partition_long#"
-  qos = "#expand qos_long#"
-  ref_name = "#expand case_name#"
+  partition = ""
+  qos = "regular"
+  ref_name = "v3.LR.historical_0051"
   run_type = "model_vs_model"
   short_ref_name = "same simulation"
   swap_test_ref = False
   tag = "model_vs_model"
   ts_num_years_ref = 2
   # Reference paths
-  reference_data_path = "#expand user_output#zppy_weekly_comprehensive_v3_output/#expand unique_id#/#expand case_name#/post/atm/180x360_aave/clim"
+  reference_data_path = "/global/cfs/cdirs/e3sm/forsyth/zppy_weekly_comprehensive_v3_output/unique_id/v3.LR.historical_0051/post/atm/180x360_aave/clim"
   # mvm streamflow only
-  gauges_path = "#expand diagnostics_base_path#/observations/Atm/time-series/GSIM/GSIM_catchment_characteristics_all_1km2.csv"
-  reference_data_path_ts_rof = "#expand user_output#zppy_weekly_comprehensive_v3_output/#expand unique_id#/#expand case_name#/post/rof/native/ts/monthly"
+  gauges_path = "/global/cfs/cdirs/e3sm/diagnostics/observations/Atm/time-series/GSIM/GSIM_catchment_characteristics_all_1km2.csv"
+  reference_data_path_ts_rof = "/global/cfs/cdirs/e3sm/forsyth/zppy_weekly_comprehensive_v3_output/unique_id/v3.LR.historical_0051/post/rof/native/ts/monthly"
   # mvm diurnal_cycle only
-  reference_data_path_climo_diurnal = "#expand user_output#zppy_weekly_comprehensive_v3_output/#expand unique_id#/#expand case_name#/post/atm/180x360_aave/clim_diurnal_8xdaily"
+  reference_data_path_climo_diurnal = "/global/cfs/cdirs/e3sm/forsyth/zppy_weekly_comprehensive_v3_output/unique_id/v3.LR.historical_0051/post/atm/180x360_aave/clim_diurnal_8xdaily"
   # mvm "enso_diags", "qbo", "area_mean_time_series"
-  reference_data_path_ts = "#expand user_output#zppy_weekly_comprehensive_v3_output/#expand unique_id#/#expand case_name#/post/atm/180x360_aave/ts/monthly"
+  reference_data_path_ts = "/global/cfs/cdirs/e3sm/forsyth/zppy_weekly_comprehensive_v3_output/unique_id/v3.LR.historical_0051/post/atm/180x360_aave/ts/monthly"
   # mvm tropical_subseasonal only
-  reference_data_path_ts_daily = "#expand user_output#zppy_weekly_comprehensive_v3_output/#expand unique_id#/#expand case_name#/post/atm/180x360_aave/ts/daily"
+  reference_data_path_ts_daily = "/global/cfs/cdirs/e3sm/forsyth/zppy_weekly_comprehensive_v3_output/unique_id/v3.LR.historical_0051/post/atm/180x360_aave/ts/daily"
 
   [[ lnd_monthly_mvm_lnd ]]
   # Test model-vs-model using the same files as the reference
   climo_subsection = "land_monthly_climo"
   diff_title = "Difference"
-  partition = "#expand partition_long#"
-  qos = "#expand qos_long#"
-  ref_name = "#expand case_name#"
+  partition = ""
+  qos = "regular"
+  ref_name = "v3.LR.historical_0051"
   run_type = "model_vs_model"
   sets = "lat_lon_land",
   short_ref_name = "same simulation"
@@ -279,18 +279,18 @@ tc_obs = "#expand diagnostics_base_path#/observations/Atm/tc-analysis/"
   tag = "model_vs_model"
   ts_num_years_ref = 2
   # Reference paths
-  reference_data_path = "#expand user_output#zppy_weekly_comprehensive_v3_output/#expand unique_id#/#expand case_name#/post/lnd/180x360_aave/clim"
+  reference_data_path = "/global/cfs/cdirs/e3sm/forsyth/zppy_weekly_comprehensive_v3_output/unique_id/v3.LR.historical_0051/post/lnd/180x360_aave/clim"
 
 [mpas_analysis]
-active = #expand active_mpas_analysis#
+active = True
 anomalyRefYear = 1985
-environment_commands = "#expand mpas_analysis_environment_commands#"
+environment_commands = "source <INSERT PATH TO CONDA>/conda.sh; conda activate <INSERT ENV NAME>"
 mesh = "IcoswISC30E3r5"
 parallelTaskCount = 6
-partition = "#expand partition_long#"
-qos = "#expand qos_long#"
+partition = ""
+qos = "regular"
 shortTermArchive = True
-walltime = "#expand mpas_analysis_walltime#"
+walltime = "03:00:00"
 
   [[ reference ]]
   ts_years = "1985-1989",
@@ -307,11 +307,11 @@ walltime = "#expand mpas_analysis_walltime#"
   test_data_path = [[ test ]]
 
 [global_time_series]
-active = #expand active_global_time_series#
+active = True
 climo_years = "1985-1989", "1990-1995",
-environment_commands = "#expand global_time_series_environment_commands#"
-experiment_name = "#expand case_name#"
-figstr = "#expand case_name#"
+environment_commands = "source <INSERT PATH TO CONDA>/conda.sh; conda activate <INSERT ENV NAME>"
+experiment_name = "v3.LR.historical_0051"
+figstr = "v3.LR.historical_0051"
 #moc_file=mocTimeSeries_1985-1995.nc
 mpas_analysis_subsections = "reference", "test",
 # plots_lnd = "FSH,RH2M,LAISHA,LAISUN,QINTR,QOVER,QRUNOFF,QSOIL,QVEGE,QVEGT,SOILWATER_10CM,TSA,H2OSNO,TOTLITC,CWDC,SOIL1C,SOIL2C,SOIL3C,SOIL4C,WOOD_HARVESTC,TOTVEGC,NBP,GPP,AR,HR"
@@ -383,7 +383,7 @@ years = "1985-1995",
   [[ all_lnd_var_viewer ]]
   # 1. plot ALL land variables
   make_viewer = True
-  partition = "#expand partition_long#"
+  partition = ""
   plots_lnd = "all"
   plots_original = ""
   walltime = "03:00:00"
@@ -394,13 +394,13 @@ years = "1985-1995",
 
 
 [ilamb]
-active = #expand active_ilamb#
+active = True
 e3sm_to_cmip_atm_subsection = "atm_monthly_180x360_aave"
 e3sm_to_cmip_land_subsection = "land_monthly"
-ilamb_obs = "#expand diagnostics_base_path#/ilamb_data"
+ilamb_obs = "/global/cfs/cdirs/e3sm/diagnostics/ilamb_data"
 nodes = 8
-partition = "#expand partition_short#"
-short_name = "#expand case_name#"
+partition = ""
+short_name = "v3.LR.historical_0051"
 ts_atm_subsection = "atm_monthly_180x360_aave"
 ts_land_subsection = "land_monthly"
 ts_num_years = 2
@@ -408,11 +408,11 @@ walltime = "2:00:00"
 years = "1985:1989:4"
 
 [livvkit]
-active = #expand active_livvkit#
+active = True
 climo_subsections = "land_monthly_180x360_traave","land_monthly_climo_native","land_monthly_climo_racmo_gis","land_monthly_climo_racmo_ais","land_monthly_climo_merra2","land_monthly_climo_era5"
 cfg = "inclusions/livvkit/livvkit_r05.jinja"
 debug = True
-environment_commands = "#expand livvkit_environment_commands#"
+environment_commands = "source <INSERT PATH TO CONDA>/conda.sh; conda activate <INSERT ENV NAME>"
 icesheets = "gis,ais"
 nodes = 1
 sets = "energy_racmo,energy_era5,energy_merra2,energy_ceres"
@@ -422,15 +422,15 @@ years = "1985:1994:10"
 
 
 [pcmdi_diags]
-active = #expand active_pcmdi_diags#
-environment_commands_secondary = "#expand pcmdi_diags_environment_commands#"
+active = True
+environment_commands_secondary = "source <INSERT PATH TO CONDA>/conda.sh; conda activate <INSERT ENV NAME>"
 walltime = "2:00:00"
 model_name = 'e3sm.historical.v3-LR.0051'
 model_tableID = 'Amon'
 e3sm_to_cmip_atm_subsection = "atm_monthly_180x360_aave" # Can be inferred if needed
 multiprocessing = True
 num_workers = 24
-obs_ts = '#expand path_pcmdi_diags_obs_ts#'
+obs_ts = '/global/cfs/cdirs/e3sm/diagnostics/observations/Atm/time-series/'
 pcmdi_debug = False
 ts_num_years = 2
 ts_years = "1985-1994",
@@ -489,5 +489,5 @@ ts_years = "1985-1994",
   movc_years = "1985-1994"
   enso_viewer = False
   enso_years = ""
-  cmip_clim_dir = #expand diagnostics_base_path#/pcmdi_data/metrics_data/mean_climate
-  cmip_movs_dir = #expand diagnostics_base_path#/pcmdi_data/metrics_data/variability_modes
+  cmip_clim_dir = /global/cfs/cdirs/e3sm/diagnostics/pcmdi_data/metrics_data/mean_climate
+  cmip_movs_dir = /global/cfs/cdirs/e3sm/diagnostics/pcmdi_data/metrics_data/variability_modes

--- a/tests/integration/generated/test_weekly_comprehensive_v3_pm-cpu.cfg
+++ b/tests/integration/generated/test_weekly_comprehensive_v3_pm-cpu.cfg
@@ -43,7 +43,7 @@ walltime = "00:30:00"
    active = True
   input_files = "elm.h0"
   input_subdir = "archive/lnd/hist"
-  mapping_file = "/global/cfs/cdirs/e3sm/diagnostics/maps/map_r05_to_cmip6_180x360_traave.20240901.nc"
+  mapping_file = "/global/cfs/cdirs/e3sm/diagnostics/maps/map_r05_to_cmip6_180x360_traave.20231110.nc"
   vars = ""
   years = "1985:1994:10",
 

--- a/tests/integration/generated/test_weekly_legacy_3.1.0_bundles_pm-cpu.cfg
+++ b/tests/integration/generated/test_weekly_legacy_3.1.0_bundles_pm-cpu.cfg
@@ -1,0 +1,171 @@
+# Test bundles.
+# Run this cfg twice.
+# Wait for the first run to finish before running again.
+#
+# 1st run of this cfg:
+# bundle 1:
+#   climo > atm_monthly_180x360_aave
+#         > atm_monthly_diurnal_8xdaily_180x360_aave
+#   ts > atm_monthly_180x360_aave
+#      > land_monthly
+#   e3sm_to_cmip > atm_monthly_180x360_aave
+#                > land_monthly
+#   e3sm_diags > atm_monthly_180x360_aave
+# bundle 2:
+#   ts > atm_monthly_glb
+#   global_time_series
+#
+# 2nd run of this cfg:
+# bundle 3:
+#   ts > rof_monthly
+#   tc_analysis
+#   e3sm_diags > atm_monthly_180x360_aave_mvm
+# no bundle:
+#   ilamb
+
+[default]
+case = "v3.LR.historical_0051"
+constraint = "cpu"
+dry_run = "False"
+environment_commands = ""
+input = /global/cfs/cdirs/e3sm/forsyth//E3SMv3/v3.LR.historical_0051
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+# To run this test, edit `output` and `www` in this file, along with `actual_images_dir` in test_bundles.py
+output = "/global/cfs/cdirs/e3sm/forsyth/zppy_weekly_legacy_3.1.0_bundles_output/unique_id/v3.LR.historical_0051"
+partition = ""
+qos = "regular"
+walltime = "6:00:00"
+www = "/global/cfs/cdirs/e3sm/www/forsyth/zppy_weekly_legacy_3.1.0_bundles_www/unique_id"
+
+[bundle]
+
+  [[ bundle2 ]]
+  nodes = 2
+  walltime = "00:59:00"
+
+[climo]
+active = True
+bundle = "bundle1"
+years = "1985:1989:2",
+
+  [[ atm_monthly_180x360_aave ]]
+  frequency = "monthly"
+
+  [[ atm_monthly_diurnal_8xdaily_180x360_aave ]]
+  active = True
+  frequency = "diurnal_8xdaily"
+  input_files = "eam.h3"
+  input_subdir = "archive/atm/hist"
+  vars = "PRECT"
+
+[ts]
+active = True
+bundle = "bundle1"
+years = "1985:1989:2",
+
+  [[ atm_monthly_180x360_aave ]]
+  frequency = "monthly"
+  input_files = "eam.h0"
+  input_subdir = "archive/atm/hist"
+
+  [[ atm_monthly_glb ]]
+  active = True
+  bundle = "bundle2" # Override bundle1
+  frequency = "monthly"
+  input_files = "eam.h0"
+  input_subdir = "archive/atm/hist"
+  mapping_file = "glb"
+  years = "1985:1995:5",
+
+  [[ land_monthly ]]
+  extra_vars = "landfrac"
+  frequency = "monthly"
+  input_files = "elm.h0"
+  input_subdir = "archive/lnd/hist"
+  mapping_file = "map_r05_to_cmip6_180x360_aave.20231110.nc"
+  vars = "LAISHA,LAISUN"
+
+  [[ rof_monthly ]]
+  active = True
+  bundle = "bundle3" # Override bundle1, let bundle1 finish first because "e3sm_diags: atm_monthly_180x360_aave_mvm" requires "ts: atm_monthly_180x360_aave"
+  extra_vars = 'areatotal2'
+  frequency = "monthly"
+  input_files = "mosart.h0"
+  input_subdir = "archive/rof/hist"
+  mapping_file = ""
+  vars = "RIVER_DISCHARGE_OVER_LAND_LIQ"
+
+[e3sm_to_cmip]
+active = True
+bundle = "bundle1"
+frequency = "monthly"
+ts_num_years = 2
+years = "1985:1989:2",
+
+  [[ atm_monthly_180x360_aave ]]
+  input_files = "eam.h0"
+
+  [[ land_monthly ]]
+  input_files = "elm.h0"
+
+# TODO: Add "tc_analysis" back in after empty dat is resolved.
+# [tc_analysis]
+# active = True
+# bundle = "bundle3" # Let bundle1 finish first because "e3sm_diags: atm_monthly_180x360_aave_mvm" requires "ts: atm_monthly_180x360_aave"
+# years = "1985:1989:2",
+
+[e3sm_diags]
+active = True
+environment_commands = "source <INSERT PATH TO CONDA>/conda.sh; conda activate <INSERT ENV NAME>"
+grid = '180x360_aave'
+ref_final_yr = 1989
+ref_start_yr = 1985
+short_name = "v3.LR.historical_0051"
+ts_num_years = 2
+years = "1985:1989:2",
+
+  [[ atm_monthly_180x360_aave ]]
+  bundle = "bundle1"
+  climo_diurnal_frequency = "diurnal_8xdaily"
+  climo_diurnal_subsection = "atm_monthly_diurnal_8xdaily_180x360_aave"
+  sets = "polar","enso_diags","diurnal_cycle",
+
+  [[ atm_monthly_180x360_aave_mvm ]]
+  # Test model-vs-model using the same files as the reference
+  bundle = "bundle3"
+  climo_subsection = "atm_monthly_180x360_aave"
+  diff_title = "Difference"
+  ref_final_yr = 1986
+  ref_name = "v3.LR.historical_0051"
+  ref_start_yr = 1985
+  ref_years = "1985-1986",
+  reference_data_path = "/global/cfs/cdirs/e3sm/forsyth/zppy_weekly_legacy_3.1.0_bundles_output/unique_id/v3.LR.historical_0051/post/atm/180x360_aave/clim"
+  run_type = "model_vs_model"
+  # TODO: Add "tc_analysis" back in after empty dat is resolved.
+  sets = "polar","enso_diags","streamflow",
+  short_ref_name = "v3.LR.historical_0051"
+  swap_test_ref = False
+  tag = "model_vs_model"
+  ts_num_years_ref = 2
+  ts_subsection = "atm_monthly_180x360_aave"
+  years = "1987-1988"
+
+[global_time_series]
+active = True
+bundle = "bundle2"
+environment_commands = "source <INSERT PATH TO CONDA>/conda.sh; conda activate <INSERT ENV NAME>"
+experiment_name = "v3.LR.historical_0051"
+figstr = "v3.LR.historical_0051"
+plots_original="net_toa_flux_restom,global_surface_air_temperature,toa_radiation,net_atm_energy_imbalance,net_atm_water_imbalance"
+ts_num_years = 5
+walltime = "00:30:00" # bundle2 should take walltime from "ts: atm_monthly_glb", i.e., "02:00:00"
+years = "1985-1995",
+
+[ilamb]
+active = True
+# No bundle, let bundle1 finish first because "ilamb" requires "ts: atm_monthly_180x360_aave" and "ts: land_monthly"
+grid = '180x360_aave'
+short_name = "v3.LR.historical_0051"
+ts_num_years = 2
+years = "1985:1987:2",

--- a/tests/integration/generated/test_weekly_legacy_3.1.0_bundles_pm-cpu.cfg
+++ b/tests/integration/generated/test_weekly_legacy_3.1.0_bundles_pm-cpu.cfg
@@ -99,6 +99,7 @@ years = "1985:1989:2",
 [e3sm_to_cmip]
 active = True
 bundle = "bundle1"
+environment_commands = "source <INSERT PATH TO CONDA>/conda.sh; conda activate <INSERT ENV NAME>"
 frequency = "monthly"
 ts_num_years = 2
 years = "1985:1989:2",

--- a/tests/integration/generated/test_weekly_legacy_3.1.0_comprehensive_v2_pm-cpu.cfg
+++ b/tests/integration/generated/test_weekly_legacy_3.1.0_comprehensive_v2_pm-cpu.cfg
@@ -1,0 +1,201 @@
+[default]
+case = "v2.LR.historical_0201"
+constraint = "cpu"
+dry_run = "False"
+environment_commands = ""
+fail_on_dependency_skip = True
+input = /global/cfs/cdirs/e3sm/forsyth//E3SMv2/v2.LR.historical_0201
+input_subdir = archive/atm/hist
+mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
+output = "/global/cfs/cdirs/e3sm/forsyth/zppy_weekly_legacy_3.1.0_comprehensive_v2_output/unique_id/v2.LR.historical_0201"
+partition = ""
+qos = "regular"
+www = "/global/cfs/cdirs/e3sm/www/forsyth/zppy_weekly_legacy_3.1.0_comprehensive_v2_www/unique_id"
+years = "1980:1984:2",
+
+[climo]
+active = True
+walltime = "00:30:00"
+
+  [[ atm_monthly_180x360_aave ]]
+  frequency = "monthly"
+  input_files = "eam.h0"
+  input_subdir = "archive/atm/hist"
+  vars = ""
+
+  [[ atm_monthly_diurnal_8xdaily_180x360_aave ]]
+  active = True
+  frequency = "diurnal_8xdaily"
+  input_files = "eam.h3"
+  input_subdir = "archive/atm/hist"
+  vars = "PRECT"
+
+  [[ land_monthly_climo ]]
+  active = True
+  frequency = "monthly"
+  input_files = "elm.h0"
+  input_subdir = "archive/lnd/hist"
+  vars = ""
+
+[ts]
+active = True
+walltime = "00:30:00"
+
+  [[ atm_monthly_180x360_aave ]]
+  frequency = "monthly"
+  input_files = "eam.h0"
+  input_subdir = "archive/atm/hist"
+
+  [[ atm_daily_180x360_aave ]]
+  active = True
+  frequency = "daily"
+  input_files = "eam.h1"
+  input_subdir = "archive/atm/hist"
+  vars = "PRECT"
+
+  [[ rof_monthly ]]
+  active = True
+  extra_vars = 'areatotal2'
+  frequency = "monthly"
+  input_files = "mosart.h0"
+  input_subdir = "archive/rof/hist"
+  mapping_file = ""
+  vars = "RIVER_DISCHARGE_OVER_LAND_LIQ"
+
+  [[ atm_monthly_glb ]]
+  # Note global average won't work for 3D variables.
+  active = True
+  frequency = "monthly"
+  input_files = "eam.h0"
+  input_subdir = "archive/atm/hist"
+  mapping_file = "glb"
+  years = "1980:1990:5",
+
+  [[ lnd_monthly_glb ]]
+  active = True
+  frequency = "monthly"
+  input_files = "elm.h0"
+  input_subdir = "archive/lnd/hist"
+  mapping_file = "glb"
+  vars = "LAISHA,LAISUN"
+  years = "1980:1990:5",
+
+  [[ land_monthly ]]
+  extra_vars = "landfrac"
+  frequency = "monthly"
+  input_files = "elm.h0"
+  input_subdir = "archive/lnd/hist"
+  vars = "LAISHA,LAISUN"
+
+[e3sm_to_cmip]
+active = True
+frequency = "monthly"
+ts_num_years=2
+walltime = "00:30:00"
+
+  [[ atm_monthly_180x360_aave ]]
+  input_files = "eam.h0"
+
+  [[ land_monthly ]]
+  input_files = "elm.h0"
+
+[tc_analysis]
+active = True
+walltime = "00:30:00"
+
+[e3sm_diags]
+active = True
+climo_diurnal_frequency = "diurnal_8xdaily"
+climo_diurnal_subsection = "atm_monthly_diurnal_8xdaily_180x360_aave"
+environment_commands = "source <INSERT PATH TO CONDA>/conda.sh; conda activate <INSERT ENV NAME>"
+grid = '180x360_aave'
+multiprocessing = True
+num_workers = 8
+partition = ""
+qos = "regular"
+ref_final_yr = 1981
+ref_start_yr = 1980
+ref_years = "1980-1981",
+# Include all sets
+# min_case_e3sm_diags_depend_on_climo: "lat_lon","zonal_mean_xy","zonal_mean_2d","polar","cosp_histogram","meridional_mean_2d","annual_cycle_zonal_mean","zonal_mean_2d_stratosphere","aerosol_aeronet","aerosol_budget",
+# min_case_e3sm_diags_depend_on_ts: "enso_diags","qbo",
+# min_case_e3sm_diags_diurnal_cycle: "diurnal_cycle",
+# min_case_e3sm_diags_streamflow: "streamflow",
+# min_case_e3sm_diags_tc_analysis: "tc_analysis",
+# min_case_e3sm_diags_tropical_subseasonal: "tropical_subseasonal",
+sets = "lat_lon","zonal_mean_xy","zonal_mean_2d","polar","cosp_histogram","meridional_mean_2d","annual_cycle_zonal_mean","zonal_mean_2d_stratosphere","enso_diags","qbo","diurnal_cycle","streamflow","tc_analysis","tropical_subseasonal","aerosol_aeronet","aerosol_budget",
+short_name = "v2.LR.historical_0201"
+ts_num_years = 2
+walltime = "6:00:00"
+years = "1982:1984:2",
+
+  [[ atm_monthly_180x360_aave ]]
+  climo_subsection = "atm_monthly_180x360_aave"
+  dc_obs_climo = '/global/cfs/cdirs/e3sm/diagnostics/observations/Atm/climatology/'
+
+  [[ atm_monthly_180x360_aave_mvm ]]
+  # Test model-vs-model using the same files as the reference
+  climo_subsection = "atm_monthly_180x360_aave"
+  diff_title = "Difference"
+  partition = ""
+  qos = "regular"
+  ref_name = "v2.LR.historical_0201"
+  reference_data_path = "/global/cfs/cdirs/e3sm/forsyth/zppy_weekly_legacy_3.1.0_comprehensive_v2_output/unique_id/v2.LR.historical_0201/post/atm/180x360_aave/clim"
+  run_type = "model_vs_model"
+  short_ref_name = "same simulation"
+  swap_test_ref = False
+  tag = "model_vs_model"
+  ts_daily_subsection = "atm_monthly_180x360_aave"
+  ts_num_years_ref = 2
+  ts_subsection = "atm_monthly_180x360_aave"
+  years = "1980:1982:2",
+
+  [[ lnd_monthly_mvm_lnd ]]
+  # Test model-vs-model using the same files as the reference
+  climo_subsection = "land_monthly_climo"
+  diff_title = "Difference"
+  partition = ""
+  qos = "regular"
+  ref_name = "v2.LR.historical_0201"
+  reference_data_path = "/global/cfs/cdirs/e3sm/forsyth/zppy_weekly_legacy_3.1.0_comprehensive_v2_output/unique_id/v2.LR.historical_0201/post/lnd/180x360_aave/clim"
+  run_type = "model_vs_model"
+  sets = "lat_lon_land",
+  short_ref_name = "same simulation"
+  swap_test_ref = False
+  tag = "model_vs_model"
+  ts_num_years_ref = 2
+
+[mpas_analysis]
+active = True
+anomalyRefYear = 1980
+climo_years ="1980-1984", "1985-1990",
+enso_years = "1980-1984", "1985-1990",
+mesh = "EC30to60E2r2"
+parallelTaskCount = 6
+partition = ""
+qos = "regular"
+shortTermArchive = True
+ts_years = "1980-1984", "1980-1990",
+walltime = "03:00:00"
+
+[global_time_series]
+active = True
+climo_years ="1980-1984", "1985-1990",
+environment_commands = "source <INSERT PATH TO CONDA>/conda.sh; conda activate <INSERT ENV NAME>"
+experiment_name = "v2.LR.historical_0201"
+figstr = "v2.LR.historical_0201"
+moc_file=mocTimeSeries_1980-1990.nc
+plots_lnd = "LAISHA,LAISUN"
+ts_num_years = 5
+ts_years = "1980-1984", "1980-1990",
+walltime = "00:30:00"
+years = "1980-1990",
+
+[ilamb]
+active = True
+nodes = 8
+partition = ""
+short_name = "v2.LR.historical_0201"
+ts_num_years = 2
+walltime = "2:00:00"
+years = "1980:1984:2",

--- a/tests/integration/generated/test_weekly_legacy_3.1.0_comprehensive_v2_pm-cpu.cfg
+++ b/tests/integration/generated/test_weekly_legacy_3.1.0_comprehensive_v2_pm-cpu.cfg
@@ -89,6 +89,7 @@ walltime = "00:30:00"
 
 [e3sm_to_cmip]
 active = True
+environment_commands = "source <INSERT PATH TO CONDA>/conda.sh; conda activate <INSERT ENV NAME>"
 frequency = "monthly"
 ts_num_years=2
 walltime = "00:30:00"

--- a/tests/integration/generated/test_weekly_legacy_3.1.0_comprehensive_v3_pm-cpu.cfg
+++ b/tests/integration/generated/test_weekly_legacy_3.1.0_comprehensive_v3_pm-cpu.cfg
@@ -100,7 +100,7 @@ walltime = "00:30:00"
 
   [[ atm_monthly_180x360_aave ]]
   cmip_plevdata = "/global/cfs/cdirs/e3sm/diagnostics/e3sm_to_cmip_data/maps/vrt_remap_plev19.nc"
-  cmip_vars = "ua, va, ta, wa, zg, hur, tas, ts, psl, ps, sfcWind, huss, pr, prc, prsn, evspsbl, tauu, tauv, hfls, clt, rlus, rsds, rsus, hfss, clivi, clwvi, rlut, rsdt, rsuscs, rsut, rtmt, abs550aer, od550aer, rsdscs, tasmax, tasmin"
+  cmip_vars = "ua, va, ta, wap, zg, hur, tas, ts, psl, ps, sfcWind, huss, pr, prc, prsn, evspsbl, tauu, tauv, hfls, clt, rlus, rsds, rsus, hfss, clivi, clwvi, rlut, rsdt, rsuscs, rsut, rtmt, abs550aer, od550aer, rsdscs, tasmax, tasmin"
   input_files = "eam.h0"
   ts_subsection = "atm_monthly_180x360_aave"
   vars = "ICEFRAC,LANDFRAC,OCNFRAC,PSL,FSNTC,FSNTOAC,SWCF,LWCF,FLUT,FSNT,FSNTOA,FLNT,FLNTC,FSNS,FLNS,FSNS,SHFLX,QFLX,LHFLX,TAUX,TAUY,PRECC,PRECL,PRECSC,PRECSL,TS,TREFHT,U10,QREFHT,TMQ,CLDTOT,CLDHGH,CLDMED,CLDLOW,FLDS,FSDS,TGCLDIWP,TGCLDCWP,TGCLDLWP,FLNSC,FLUTC,FSDSC,SOLIN,FSNSC,AODABS,AODVIS,AODDUST,AREL,TREFMNAV,TREFMXAV,PS,PHIS,U,V,T,Z3"

--- a/tests/integration/generated/test_weekly_legacy_3.1.0_comprehensive_v3_pm-cpu.cfg
+++ b/tests/integration/generated/test_weekly_legacy_3.1.0_comprehensive_v3_pm-cpu.cfg
@@ -1,32 +1,32 @@
 [default]
-case = "#expand case_name#"
-constraint = "#expand constraint#"
-dry_run = "#expand dry_run#"
-environment_commands = "#expand environment_commands#"
+case = "v3.LR.historical_0051"
+constraint = "cpu"
+dry_run = "False"
+environment_commands = ""
 fail_on_dependency_skip = True
 infer_path_parameters = False
 infer_section_parameters = False
-input = #expand user_input_v3#/E3SMv3/#expand case_name#
+input = /global/cfs/cdirs/e3sm/forsyth//E3SMv3/v3.LR.historical_0051
 input_subdir = archive/atm/hist
 mapping_file = "map_ne30pg2_to_cmip6_180x360_aave.20200201.nc"
-output = "#expand user_output#zppy_weekly_comprehensive_v3_output/#expand unique_id#/#expand case_name#"
-partition = "#expand partition_short#"
-qos = "#expand qos_short#"
-www = "#expand user_www#zppy_weekly_comprehensive_v3_www/#expand unique_id#"
+output = "/global/cfs/cdirs/e3sm/forsyth/zppy_weekly_legacy_3.1.0_comprehensive_v3_output/unique_id/v3.LR.historical_0051"
+partition = ""
+qos = "regular"
+www = "/global/cfs/cdirs/e3sm/www/forsyth/zppy_weekly_legacy_3.1.0_comprehensive_v3_www/unique_id"
 years = "1985:1989:2",
 
 [climo]
 active = True
-frequency = "monthly"
 walltime = "00:30:00"
 
   [[ atm_monthly_180x360_aave ]]
+  frequency = "monthly"
   input_files = "eam.h0"
   input_subdir = "archive/atm/hist"
   vars = ""
 
   [[ atm_monthly_diurnal_8xdaily_180x360_aave ]]
-  active = #expand active_e3sm_diags#
+  active = True
   frequency = "diurnal_8xdaily"
   input_files = "eam.h3"
   input_subdir = "archive/atm/hist"
@@ -34,71 +34,11 @@ walltime = "00:30:00"
 
   [[ land_monthly_climo ]]
   active = True
+  frequency = "monthly"
   input_files = "elm.h0"
   input_subdir = "archive/lnd/hist"
   mapping_file = "map_r05_to_cmip6_180x360_aave.20231110.nc"
   vars = ""
-
-  [[ land_monthly_180x360_traave ]]
-   active = #expand active_livvkit#
-  input_files = "elm.h0"
-  input_subdir = "archive/lnd/hist"
-  mapping_file = "#expand livvkit_mapping_file_path_alternative#/map_r05_to_cmip6_180x360_traave.20240901.nc"
-  vars = ""
-  years = "1985:1994:10",
-
-  [[ land_monthly_climo_native ]]
-  active = #expand active_livvkit#
-  climo_jobs = 12
-  input_files = "elm.h0"
-  input_subdir = "archive/lnd/hist"
-  mapping_file = ""
-  vars = ""
-  years = "1985:1994:10"
-
-  [[ land_monthly_climo_racmo_gis ]]
-  active = #expand active_livvkit#
-  climo_jobs = 12
-  climo_subsection = "racmo_gis"
-  grid = "racmo_gis"
-  input_files = "elm.h0"
-  input_subdir = "archive/lnd/hist"
-  mapping_file = "#expand livvkit_mapping_file_path_alternative#/map_r05_to_racmo_gis_566x438_traave.20240801.nc"
-  vars = ""
-  years = "1985:1994:10"
-
-  [[ land_monthly_climo_racmo_ais ]]
-  active = #expand active_livvkit#
-  climo_jobs = 12
-  input_files = "elm.h0"
-  climo_subsection = "racmo_ais"
-  grid = "racmo_ais"
-  input_subdir = "archive/lnd/hist"
-  mapping_file = "#expand livvkit_mapping_file_path#/map_r05_to_racmo_ais_591x726.nc"
-  vars = ""
-  years = "1985:1994:10"
-
-  [[ land_monthly_climo_merra2 ]]
-  active = #expand active_livvkit#
-  climo_jobs = 12
-  input_files = "elm.h0"
-  climo_subsection = "merra2"
-  grid = "merra2"
-  input_subdir = "archive/lnd/hist"
-  mapping_file = "#expand livvkit_mapping_file_path#/map_r05_to_merra2_traave.20250124.nc"
-  vars = ""
-  years = "1985:1994:10"
-
-  [[ land_monthly_climo_era5 ]]
-  active = #expand active_livvkit#
-  climo_jobs = 12
-  input_files = "elm.h0"
-  climo_subsection = "era5"
-  grid = "era5"
-  input_subdir = "archive/lnd/hist"
-  mapping_file = "#expand livvkit_mapping_file_path#/map_r05_to_era5_s2n_721x1440.traave.20240124.nc"
-  vars = ""
-  years = "1985:1994:10"
 
 [ts]
 active = True
@@ -109,19 +49,16 @@ walltime = "00:30:00"
   input_files = "eam.h0"
   input_subdir = "archive/atm/hist"
   years = "1985:1995:2", # Need 10 years for pcmdi_diags task
-  # We need to add extra vars to the default `vars=""` value
-  # in order to enable the e3sm_diags mp_partition set.
-  vars = "FSNTOA,FLUT,FSNT,FLNT,FSNS,FLNS,SHFLX,QFLX,TAUX,TAUY,PRECC,PRECL,PRECSC,PRECSL,TS,TREFHT,CLDTOT,CLDHGH,CLDMED,CLDLOW,U,PSL,LANDFRAC,CLD_CAL_TMPICE,CLD_CAL_TMPLIQ,CLDLIQ,T"
 
   [[ atm_daily_180x360_aave ]]
-  active = #expand active_e3sm_diags#
+  active = True
   frequency = "daily"
   input_files = "eam.h1"
   input_subdir = "archive/atm/hist"
   vars = "PRECT"
 
   [[ rof_monthly ]]
-  active = #expand active_e3sm_diags#
+  active = True
   extra_vars = 'areatotal2'
   frequency = "monthly"
   input_files = "mosart.h0"
@@ -131,7 +68,7 @@ walltime = "00:30:00"
 
   [[ atm_monthly_glb ]]
   # Note global average won't work for 3D variables.
-  active = #expand active_global_time_series#
+  active = True
   frequency = "monthly"
   input_files = "eam.h0"
   input_subdir = "archive/atm/hist"
@@ -139,7 +76,7 @@ walltime = "00:30:00"
   years = "1985:1995:5",
 
   [[ lnd_monthly_glb ]]
-  active = #expand active_global_time_series#
+  active = True
   frequency = "monthly"
   input_files = "elm.h0"
   input_subdir = "archive/lnd/hist"
@@ -155,33 +92,14 @@ walltime = "00:30:00"
   mapping_file = "map_r05_to_cmip6_180x360_aave.20231110.nc"
   vars = "FSH,RH2M,LAISHA,LAISUN,QINTR,QOVER,QRUNOFF,QSOIL,QVEGE,QVEGT,SOILICE,SOILLIQ,SOILWATER_10CM,TSA,TSOI,H2OSNO,TOTLITC,CWDC,SOIL1C,SOIL2C,SOIL3C,SOIL4C,WOOD_HARVESTC,TOTVEGC,NBP,GPP,AR,HR"
 
-  [[ land_monthly_energy ]]
-  active = #expand active_livvkit#
-  frequency = "monthly"
-  input_files = "elm.h0"
-  input_subdir = "archive/lnd/hist"
-  mapping_file = ""
-  vars = "EFLX_LH_TOT,FIRA,FLDS,FSA,FSDS,FSRND,FSRVD,FSDSND,FSDSVD,FSH,TSA"
-  years = "1985:1994:10"
-
-  [[ land_monthly_smb ]]
-  # The data necessary for this is not found in the data input path.
-  active = False
-  frequency = "monthly"
-  input_files = "elm.h0"
-  input_subdir = "archive/lnd/hist"
-  mapping_file = ""
-  vars = "QICE,QICE_MELT,QRUNOFF,QSNOFRZ,QSNOMELT,QSOIL,RAIN,SNOW"
-  years = "1985:1994:10"
-
 [e3sm_to_cmip]
-active = #expand active_e3sm_to_cmip#
+active = True
 frequency = "monthly"
 ts_num_years=2
 walltime = "00:30:00"
 
   [[ atm_monthly_180x360_aave ]]
-  cmip_plevdata = "#expand diagnostics_base_path#/e3sm_to_cmip_data/maps/vrt_remap_plev19.nc"
+  cmip_plevdata = "/global/cfs/cdirs/e3sm/diagnostics/e3sm_to_cmip_data/maps/vrt_remap_plev19.nc"
   cmip_vars = "ua, va, ta, wa, zg, hur, tas, ts, psl, ps, sfcWind, huss, pr, prc, prsn, evspsbl, tauu, tauv, hfls, clt, rlus, rsds, rsus, hfss, clivi, clwvi, rlut, rsdt, rsuscs, rsut, rtmt, abs550aer, od550aer, rsdscs, tasmax, tasmin"
   input_files = "eam.h0"
   ts_subsection = "atm_monthly_180x360_aave"
@@ -198,16 +116,16 @@ walltime = "00:30:00"
 # walltime = "00:30:00"
 
 [e3sm_diags]
-active = #expand active_e3sm_diags#
+active = True
 climo_diurnal_frequency = "diurnal_8xdaily"
 climo_diurnal_subsection = "atm_monthly_diurnal_8xdaily_180x360_aave"
 climo_subsection = "atm_monthly_180x360_aave"
-environment_commands = "#expand diags_environment_commands#"
+environment_commands = "source <INSERT PATH TO CONDA>/conda.sh; conda activate <INSERT ENV NAME>"
 grid = '180x360_aave'
 multiprocessing = True
 num_workers = 8
-partition = "#expand partition_long#"
-qos = "#expand qos_long#"
+partition = ""
+qos = "regular"
 ref_final_yr = 1986
 ref_start_yr = 1985
 ref_years = "1985-1986",
@@ -221,57 +139,56 @@ ref_years = "1985-1986",
 # TODO: Add "tc_analysis" back in after empty dat is resolved.
 # TODO: Add "aerosol_budget" back in once that's working for v3.
 sets = "lat_lon","zonal_mean_xy","zonal_mean_2d","polar","cosp_histogram","meridional_mean_2d","annual_cycle_zonal_mean","zonal_mean_2d_stratosphere","enso_diags","qbo","diurnal_cycle","streamflow","tropical_subseasonal","aerosol_aeronet",
-short_name = "#expand case_name#"
+short_name = "v3.LR.historical_0051"
 ts_daily_subsection = "atm_daily_180x360_aave"
 ts_num_years = 2
 ts_subsection = "atm_monthly_180x360_aave"
-walltime = "#expand diags_walltime#"
+walltime = "6:00:00"
 years = "1987:1989:2"
 # Reference paths
 # Used for mvo and mvm, if ts_num_years is set
-obs_ts = "#expand diagnostics_base_path#/observations/Atm/time-series/"
+obs_ts = "/global/cfs/cdirs/e3sm/diagnostics/observations/Atm/time-series/"
 # mvo & mvm tc_analysis only
-tc_obs = "#expand diagnostics_base_path#/observations/Atm/tc-analysis/"
+tc_obs = "/global/cfs/cdirs/e3sm/diagnostics/observations/Atm/tc-analysis/"
 
   [[ atm_monthly_180x360_aave ]]
   # Reference paths
-  reference_data_path = "#expand diagnostics_base_path#/observations/Atm/climatology/"
+  reference_data_path = "/global/cfs/cdirs/e3sm/diagnostics/observations/Atm/climatology/"
   # mvo diurnal_cycle only
-  dc_obs_climo = '#expand path_dc_obs_climo#'
+  dc_obs_climo = '/global/cfs/cdirs/e3sm/diagnostics/observations/Atm/climatology/'
   # mvo streamflow only
-  streamflow_obs_ts = "#expand diagnostics_base_path#/observations/Atm/time-series/"
-  sets = "lat_lon","zonal_mean_xy","zonal_mean_2d","polar","cosp_histogram","meridional_mean_2d","annual_cycle_zonal_mean","zonal_mean_2d_stratosphere","enso_diags","qbo","diurnal_cycle","streamflow","mp_partition","tropical_subseasonal","precip_pdf","aerosol_aeronet",
+  streamflow_obs_ts = "/global/cfs/cdirs/e3sm/diagnostics/observations/Atm/time-series/"
 
   [[ atm_monthly_180x360_aave_mvm ]]
   # Test model-vs-model using the same files as the reference
   diff_title = "Difference"
-  partition = "#expand partition_long#"
-  qos = "#expand qos_long#"
-  ref_name = "#expand case_name#"
+  partition = ""
+  qos = "regular"
+  ref_name = "v3.LR.historical_0051"
   run_type = "model_vs_model"
   short_ref_name = "same simulation"
   swap_test_ref = False
   tag = "model_vs_model"
   ts_num_years_ref = 2
   # Reference paths
-  reference_data_path = "#expand user_output#zppy_weekly_comprehensive_v3_output/#expand unique_id#/#expand case_name#/post/atm/180x360_aave/clim"
+  reference_data_path = "/global/cfs/cdirs/e3sm/forsyth/zppy_weekly_legacy_3.1.0_comprehensive_v3_output/unique_id/v3.LR.historical_0051/post/atm/180x360_aave/clim"
   # mvm streamflow only
-  gauges_path = "#expand diagnostics_base_path#/observations/Atm/time-series/GSIM/GSIM_catchment_characteristics_all_1km2.csv"
-  reference_data_path_ts_rof = "#expand user_output#zppy_weekly_comprehensive_v3_output/#expand unique_id#/#expand case_name#/post/rof/native/ts/monthly"
+  gauges_path = "/global/cfs/cdirs/e3sm/diagnostics/observations/Atm/time-series/GSIM/GSIM_catchment_characteristics_all_1km2.csv"
+  reference_data_path_ts_rof = "/global/cfs/cdirs/e3sm/forsyth/zppy_weekly_legacy_3.1.0_comprehensive_v3_output/unique_id/v3.LR.historical_0051/post/rof/native/ts/monthly"
   # mvm diurnal_cycle only
-  reference_data_path_climo_diurnal = "#expand user_output#zppy_weekly_comprehensive_v3_output/#expand unique_id#/#expand case_name#/post/atm/180x360_aave/clim_diurnal_8xdaily"
+  reference_data_path_climo_diurnal = "/global/cfs/cdirs/e3sm/forsyth/zppy_weekly_legacy_3.1.0_comprehensive_v3_output/unique_id/v3.LR.historical_0051/post/atm/180x360_aave/clim_diurnal_8xdaily"
   # mvm "enso_diags", "qbo", "area_mean_time_series"
-  reference_data_path_ts = "#expand user_output#zppy_weekly_comprehensive_v3_output/#expand unique_id#/#expand case_name#/post/atm/180x360_aave/ts/monthly"
+  reference_data_path_ts = "/global/cfs/cdirs/e3sm/forsyth/zppy_weekly_legacy_3.1.0_comprehensive_v3_output/unique_id/v3.LR.historical_0051/post/atm/180x360_aave/ts/monthly"
   # mvm tropical_subseasonal only
-  reference_data_path_ts_daily = "#expand user_output#zppy_weekly_comprehensive_v3_output/#expand unique_id#/#expand case_name#/post/atm/180x360_aave/ts/daily"
+  reference_data_path_ts_daily = "/global/cfs/cdirs/e3sm/forsyth/zppy_weekly_legacy_3.1.0_comprehensive_v3_output/unique_id/v3.LR.historical_0051/post/atm/180x360_aave/ts/daily"
 
   [[ lnd_monthly_mvm_lnd ]]
   # Test model-vs-model using the same files as the reference
   climo_subsection = "land_monthly_climo"
   diff_title = "Difference"
-  partition = "#expand partition_long#"
-  qos = "#expand qos_long#"
-  ref_name = "#expand case_name#"
+  partition = ""
+  qos = "regular"
+  ref_name = "v3.LR.historical_0051"
   run_type = "model_vs_model"
   sets = "lat_lon_land",
   short_ref_name = "same simulation"
@@ -279,41 +196,28 @@ tc_obs = "#expand diagnostics_base_path#/observations/Atm/tc-analysis/"
   tag = "model_vs_model"
   ts_num_years_ref = 2
   # Reference paths
-  reference_data_path = "#expand user_output#zppy_weekly_comprehensive_v3_output/#expand unique_id#/#expand case_name#/post/lnd/180x360_aave/clim"
+  reference_data_path = "/global/cfs/cdirs/e3sm/forsyth/zppy_weekly_legacy_3.1.0_comprehensive_v3_output/unique_id/v3.LR.historical_0051/post/lnd/180x360_aave/clim"
 
 [mpas_analysis]
-active = #expand active_mpas_analysis#
+active = True
 anomalyRefYear = 1985
-environment_commands = "#expand mpas_analysis_environment_commands#"
+climo_years = "1985-1989", "1990-1995",
+enso_years = "1985-1989", "1990-1995",
 mesh = "IcoswISC30E3r5"
 parallelTaskCount = 6
-partition = "#expand partition_long#"
-qos = "#expand qos_long#"
+partition = ""
+qos = "regular"
 shortTermArchive = True
-walltime = "#expand mpas_analysis_walltime#"
-
-  [[ reference ]]
-  ts_years = "1985-1989",
-  climo_years = "1985-1989",
-  enso_years = "1985-1989",
-
-  [[ test ]]
-  ts_years = "1985-1995",
-  climo_years = "1990-1995",
-  enso_years = "1990-1995",
-
-  [[ mvm ]]
-  reference_data_path = [[ reference ]]
-  test_data_path = [[ test ]]
+ts_years = "1985-1989", "1985-1995",
+walltime = "03:00:00"
 
 [global_time_series]
-active = #expand active_global_time_series#
+active = True
 climo_years = "1985-1989", "1990-1995",
-environment_commands = "#expand global_time_series_environment_commands#"
-experiment_name = "#expand case_name#"
-figstr = "#expand case_name#"
+environment_commands = "source <INSERT PATH TO CONDA>/conda.sh; conda activate <INSERT ENV NAME>"
+experiment_name = "v3.LR.historical_0051"
+figstr = "v3.LR.historical_0051"
 #moc_file=mocTimeSeries_1985-1995.nc
-mpas_analysis_subsections = "reference", "test",
 # plots_lnd = "FSH,RH2M,LAISHA,LAISUN,QINTR,QOVER,QRUNOFF,QSOIL,QVEGE,QVEGT,SOILWATER_10CM,TSA,H2OSNO,TOTLITC,CWDC,SOIL1C,SOIL2C,SOIL3C,SOIL4C,WOOD_HARVESTC,TOTVEGC,NBP,GPP,AR,HR"
 ts_num_years = 5
 ts_years = "1985-1989", "1985-1995",
@@ -383,7 +287,7 @@ years = "1985-1995",
   [[ all_lnd_var_viewer ]]
   # 1. plot ALL land variables
   make_viewer = True
-  partition = "#expand partition_long#"
+  partition = ""
   plots_lnd = "all"
   plots_original = ""
   walltime = "03:00:00"
@@ -394,43 +298,29 @@ years = "1985-1995",
 
 
 [ilamb]
-active = #expand active_ilamb#
+active = True
 e3sm_to_cmip_atm_subsection = "atm_monthly_180x360_aave"
 e3sm_to_cmip_land_subsection = "land_monthly"
-ilamb_obs = "#expand diagnostics_base_path#/ilamb_data"
+ilamb_obs = "/global/cfs/cdirs/e3sm/diagnostics/ilamb_data"
 nodes = 8
-partition = "#expand partition_short#"
-short_name = "#expand case_name#"
+partition = ""
+short_name = "v3.LR.historical_0051"
 ts_atm_subsection = "atm_monthly_180x360_aave"
 ts_land_subsection = "land_monthly"
 ts_num_years = 2
 walltime = "2:00:00"
 years = "1985:1989:4"
 
-[livvkit]
-active = #expand active_livvkit#
-climo_subsections = "land_monthly_180x360_traave","land_monthly_climo_native","land_monthly_climo_racmo_gis","land_monthly_climo_racmo_ais","land_monthly_climo_merra2","land_monthly_climo_era5"
-cfg = "inclusions/livvkit/livvkit_r05.jinja"
-debug = True
-environment_commands = "#expand livvkit_environment_commands#"
-icesheets = "gis,ais"
-nodes = 1
-sets = "energy_racmo,energy_era5,energy_merra2,energy_ceres"
-ts_land_subsection = "land_monthly_energy"
-walltime = "0:30:00"
-years = "1985:1994:10"
-
-
 [pcmdi_diags]
-active = #expand active_pcmdi_diags#
-environment_commands_secondary = "#expand pcmdi_diags_environment_commands#"
+active = True
+environment_commands_secondary = "source <INSERT PATH TO CONDA>/conda.sh; conda activate <INSERT ENV NAME>"
 walltime = "2:00:00"
 model_name = 'e3sm.historical.v3-LR.0051'
 model_tableID = 'Amon'
 e3sm_to_cmip_atm_subsection = "atm_monthly_180x360_aave" # Can be inferred if needed
 multiprocessing = True
 num_workers = 24
-obs_ts = '#expand path_pcmdi_diags_obs_ts#'
+obs_ts = '/global/cfs/cdirs/e3sm/diagnostics/observations/Atm/time-series/'
 pcmdi_debug = False
 ts_num_years = 2
 ts_years = "1985-1994",
@@ -489,5 +379,5 @@ ts_years = "1985-1994",
   movc_years = "1985-1994"
   enso_viewer = False
   enso_years = ""
-  cmip_clim_dir = #expand diagnostics_base_path#/pcmdi_data/metrics_data/mean_climate
-  cmip_movs_dir = #expand diagnostics_base_path#/pcmdi_data/metrics_data/variability_modes
+  cmip_clim_dir = /global/cfs/cdirs/e3sm/diagnostics/pcmdi_data/metrics_data/mean_climate
+  cmip_movs_dir = /global/cfs/cdirs/e3sm/diagnostics/pcmdi_data/metrics_data/variability_modes

--- a/tests/integration/generated/test_weekly_legacy_3.1.0_comprehensive_v3_pm-cpu.cfg
+++ b/tests/integration/generated/test_weekly_legacy_3.1.0_comprehensive_v3_pm-cpu.cfg
@@ -94,6 +94,7 @@ walltime = "00:30:00"
 
 [e3sm_to_cmip]
 active = True
+environment_commands = "source <INSERT PATH TO CONDA>/conda.sh; conda activate <INSERT ENV NAME>"
 frequency = "monthly"
 ts_num_years=2
 walltime = "00:30:00"

--- a/tests/integration/generated/update_archive_expected_files_pm-cpu.sh
+++ b/tests/integration/generated/update_archive_expected_files_pm-cpu.sh
@@ -1,0 +1,9 @@
+# Take the latest expected files and archive them as "official"
+# I.e., the expected results for a zppy release or Unified release
+
+release_name=""
+
+for test_name in "comprehensive_v2" "comprehensive_v3" "bundles"
+do
+  cp -r /global/cfs/cdirs/e3sm/www/zppy_test_resources/expected_${test_name} /global/cfs/cdirs/e3sm/www/zppy_test_resources/${test_name}_${release_name}
+done

--- a/tests/integration/generated/update_bash_generation_expected_files_pm-cpu.sh
+++ b/tests/integration/generated/update_bash_generation_expected_files_pm-cpu.sh
@@ -1,0 +1,11 @@
+# Run this script to update expected files for test_bash_generation.py
+# Run from the top level of the zppy repo
+# Run as `./tests/integration/generated/update_bash_generation_expected_files.sh`
+
+rm -rf /global/cfs/cdirs/e3sm/www/zppy_test_resources/expected_bash_files
+# Your output will now become the new expectation.
+# You can just move (i.e., not copy) the output since re-running this test will re-generate the output.
+rm -rf test_bash_generation_output/post/scripts/provenance*
+mv test_bash_generation_output/post/scripts /global/cfs/cdirs/e3sm/www/zppy_test_resources/expected_bash_files
+# Rerun test
+pytest tests/integration/test_bash_generation.py

--- a/tests/integration/generated/update_campaign_expected_files_pm-cpu.sh
+++ b/tests/integration/generated/update_campaign_expected_files_pm-cpu.sh
@@ -1,0 +1,16 @@
+# Run this script to update expected files for test_campaign.py
+# Run from the top level of the zppy repo
+# Run as `./tests/integration/generated/update_campaign_expected_files.sh`
+
+for campaign in "cryosphere" "cryosphere_override" "high_res_v1" "none" "water_cycle" "water_cycle_override"
+do
+    echo ${campaign}
+    rm -rf /global/cfs/cdirs/e3sm/www/zppy_test_resources/test_campaign_${campaign}_expected_files
+    mkdir -p /global/cfs/cdirs/e3sm/www/zppy_test_resources/test_campaign_${campaign}_expected_files
+    # Your output will now become the new expectation.
+    # You can just move (i.e., not copy) the output since re-running this test will re-generate the output.
+    mv test_campaign_${campaign}_output/post/scripts/*.settings /global/cfs/cdirs/e3sm/www/zppy_test_resources/test_campaign_${campaign}_expected_files
+done
+
+# Rerun test
+pytest tests/integration/test_campaign.py

--- a/tests/integration/generated/update_defaults_expected_files_pm-cpu.sh
+++ b/tests/integration/generated/update_defaults_expected_files_pm-cpu.sh
@@ -1,0 +1,11 @@
+# Run this script to update expected files for test_defaults.py
+# Run from the top level of the zppy repo
+# Run as `./tests/integration/generated/update_defaults_expected_files.sh`
+
+rm -rf /global/cfs/cdirs/e3sm/www/zppy_test_resources/test_defaults_expected_files
+mkdir -p /global/cfs/cdirs/e3sm/www/zppy_test_resources/test_defaults_expected_files
+# Your output will now become the new expectation.
+# You can just move (i.e., not copy) the output since re-running this test will re-generate the output.
+mv test_defaults_output/post/scripts/*.settings /global/cfs/cdirs/e3sm/www/zppy_test_resources/test_defaults_expected_files
+# Rerun test
+pytest tests/integration/test_defaults.py

--- a/tests/integration/generated/update_weekly_expected_files_pm-cpu.sh
+++ b/tests/integration/generated/update_weekly_expected_files_pm-cpu.sh
@@ -1,0 +1,66 @@
+# Run this script to update expected files used by both test_bundles.py & test_images.py.
+# Run from the top level of the zppy repo
+# Run as `./tests/integration/generated/update_weekly_expected_files_pm-cpu.sh`
+
+
+# NOTE: in `tests` below, do *not* include the `zppy_weekly_` prefix, as that is added later.
+
+# Update all
+tests=("comprehensive_v2" "comprehensive_v3" "bundles" "legacy_3.1.0_comprehensive_v2" "legacy_3.1.0_comprehensive_v3" "legacy_3.1.0_bundles" "legacy_3.0.0_comprehensive_v2" "legacy_3.0.0_comprehensive_v3" "legacy_3.0.0_bundles")
+
+# Update regular only
+#tests=("comprehensive_v2" "comprehensive_v3" "bundles")
+
+# Update legacy 3.1.0 only
+#tests=("legacy_3.1.0_comprehensive_v2" "legacy_3.1.0_comprehensive_v3" "legacy_3.1.0_bundles")
+
+# Update legacy 3.0.0 only
+#tests=("legacy_3.0.0_comprehensive_v2" "legacy_3.0.0_comprehensive_v3" "legacy_3.0.0_bundles")
+
+for test_name in "${tests[@]}"
+do
+    # Example for Chrysalis:
+    #
+    # expected_dir = /lcrc/group/e3sm/public_html/zppy_test_resources/
+    #
+    # There are 9 subdirectories relevant to image checking:
+    # 1-3. expected_bundles, expected_comprehensive_v2, expected_comprehensive_v3
+    # 4-6. expected_legacy_3.1.0_bundles, expected_legacy_3.1.0_comprehensive_v2, expected_legacy_3.1.0_comprehensive_v3
+    # 7-9. expected_legacy_3.0.0_bundles, expected_legacy_3.0.0_comprehensive_v2, expected_legacy_3.0.0_comprehensive_v3
+    # Notice the subdirectories do *not* include the `zppy_weekly` prefix.
+    #
+    # Each of those subdirectories has a corresponding image list of the form:
+    # `image_list_<subdir_name>.txt`
+
+    # Remove old expected files.
+    rm -rf /global/cfs/cdirs/e3sm/www/zppy_test_resources/expected_${test_name}
+
+    # Your output will now become the new expectation.
+    # Copy output so you don't have to rerun zppy to generate the output.
+    if [[ "${test_name,,}" =~ "v2" ]]; then
+      # We need the v2 case name
+      cp -r /global/cfs/cdirs/e3sm/www/forsyth/zppy_weekly_${test_name}_www/unique_id/v2.LR.historical_0201 /global/cfs/cdirs/e3sm/www/zppy_test_resources/expected_${test_name}
+    else
+      # We need the v3 case name
+      cp -r /global/cfs/cdirs/e3sm/www/forsyth/zppy_weekly_${test_name}_www/unique_id/v3.LR.historical_0051 /global/cfs/cdirs/e3sm/www/zppy_test_resources/expected_${test_name}
+    fi
+
+    # test_bundles.py also needs the bash files transferred.
+    # Note that for legacy cfgs, we're only testing test_images.py
+    if [[ "${test_name,,}" == "bundles" ]]; then
+      mkdir -p /global/cfs/cdirs/e3sm/www/zppy_test_resources/expected_bundles/bundle_files
+      cp -r /global/cfs/cdirs/e3sm/forsyth/zppy_weekly_bundles_output/unique_id/v3.LR.historical_0051/post/scripts/bundle*.bash /global/cfs/cdirs/e3sm/www/zppy_test_resources/expected_bundles/bundle_files
+    fi
+
+    zppy_top_level=$(pwd)
+    cd /global/cfs/cdirs/e3sm/www/zppy_test_resources/expected_${test_name}
+    # Remove the image check failures, so they don't end up in the expected files.
+    rm -rf image_check_failures_${test_name}
+    # This file will list all the expected images.
+    find . -type f -name '*.png' > ../image_list_expected_${test_name}.txt
+    cd ${zppy_top_level}
+done
+
+# To rerun tests:
+# pytest tests/integration/test_bundles.py
+# pytest tests/integration/test_images.py

--- a/tests/integration/template_min_case_carryover_dependencies.cfg
+++ b/tests/integration/template_min_case_carryover_dependencies.cfg
@@ -139,7 +139,7 @@ years = "1987:1989:2"
   climo_diurnal_frequency = "diurnal_8xdaily"
   climo_diurnal_subsection = "atm_monthly_diurnal_8xdaily_180x360_aave"
   climo_subsection = "atm_monthly_180x360_aave"
-  dc_obs_climo = '/lcrc/group/e3sm/public_html/e3sm_diags_test_data/unit_test_complete_run/obs/climatology'
+  dc_obs_climo = '#expand path_dc_obs_climo#'
   # TODO: Add "tc_analysis" back in after empty dat is resolved.
   #sets = "lat_lon","tc_analysis"
   sets = "lat_lon",

--- a/tests/integration/template_min_case_e3sm_diags_diurnal_cycle.cfg
+++ b/tests/integration/template_min_case_e3sm_diags_diurnal_cycle.cfg
@@ -37,5 +37,5 @@ walltime = "#expand diags_walltime#"
   [[ atm_monthly_180x360_aave ]]
   climo_diurnal_frequency = "diurnal_8xdaily"
   climo_diurnal_subsection = "atm_monthly_diurnal_8xdaily_180x360_aave"
-  dc_obs_climo = '/lcrc/group/e3sm/public_html/e3sm_diags_test_data/unit_test_complete_run/obs/climatology'
+  dc_obs_climo = '#expand path_dc_obs_climo#'
   sets = "diurnal_cycle",

--- a/tests/integration/template_weekly_bundles.cfg
+++ b/tests/integration/template_weekly_bundles.cfg
@@ -99,6 +99,7 @@ years = "1985:1989:2",
 [e3sm_to_cmip]
 active = #expand active_e3sm_to_cmip#
 bundle = "bundle1"
+environment_commands = "#expand e3sm_to_cmip_environment_commands#"
 frequency = "monthly"
 ts_num_years = 2
 years = "1985:1989:2",

--- a/tests/integration/template_weekly_comprehensive_v2.cfg
+++ b/tests/integration/template_weekly_comprehensive_v2.cfg
@@ -89,6 +89,7 @@ walltime = "00:30:00"
 
 [e3sm_to_cmip]
 active = #expand active_e3sm_to_cmip#
+environment_commands = "#expand e3sm_to_cmip_environment_commands#"
 frequency = "monthly"
 ts_num_years=2
 walltime = "00:30:00"

--- a/tests/integration/template_weekly_comprehensive_v3.cfg
+++ b/tests/integration/template_weekly_comprehensive_v3.cfg
@@ -182,7 +182,7 @@ walltime = "00:30:00"
 
   [[ atm_monthly_180x360_aave ]]
   cmip_plevdata = "#expand diagnostics_base_path#/e3sm_to_cmip_data/maps/vrt_remap_plev19.nc"
-  cmip_vars = "ua, va, ta, wa, zg, hur, tas, ts, psl, ps, sfcWind, huss, pr, prc, prsn, evspsbl, tauu, tauv, hfls, clt, rlus, rsds, rsus, hfss, clivi, clwvi, rlut, rsdt, rsuscs, rsut, rtmt, abs550aer, od550aer, rsdscs, tasmax, tasmin"
+  cmip_vars = "ua, va, ta, wap, zg, hur, tas, ts, psl, ps, sfcWind, huss, pr, prc, prsn, evspsbl, tauu, tauv, hfls, clt, rlus, rsds, rsus, hfss, clivi, clwvi, rlut, rsdt, rsuscs, rsut, rtmt, abs550aer, od550aer, rsdscs, tasmax, tasmin"
   input_files = "eam.h0"
   ts_subsection = "atm_monthly_180x360_aave"
   vars = "ICEFRAC,LANDFRAC,OCNFRAC,PSL,FSNTC,FSNTOAC,SWCF,LWCF,FLUT,FSNT,FSNTOA,FLNT,FLNTC,FSNS,FLNS,FSNS,SHFLX,QFLX,LHFLX,TAUX,TAUY,PRECC,PRECL,PRECSC,PRECSL,TS,TREFHT,U10,QREFHT,TMQ,CLDTOT,CLDHGH,CLDMED,CLDLOW,FLDS,FSDS,TGCLDIWP,TGCLDCWP,TGCLDLWP,FLNSC,FLUTC,FSDSC,SOLIN,FSNSC,AODABS,AODVIS,AODDUST,AREL,TREFMNAV,TREFMXAV,PS,PHIS,U,V,T,Z3"

--- a/tests/integration/template_weekly_comprehensive_v3.cfg
+++ b/tests/integration/template_weekly_comprehensive_v3.cfg
@@ -43,7 +43,7 @@ walltime = "00:30:00"
    active = #expand active_livvkit#
   input_files = "elm.h0"
   input_subdir = "archive/lnd/hist"
-  mapping_file = "#expand livvkit_mapping_file_path_alternative#/map_r05_to_cmip6_180x360_traave.20240901.nc"
+  mapping_file = "#expand livvkit_mapping_file_path#/map_r05_to_cmip6_180x360_traave.20231110.nc"
   vars = ""
   years = "1985:1994:10",
 
@@ -63,7 +63,7 @@ walltime = "00:30:00"
   grid = "racmo_gis"
   input_files = "elm.h0"
   input_subdir = "archive/lnd/hist"
-  mapping_file = "#expand livvkit_mapping_file_path_alternative#/map_r05_to_racmo_gis_566x438_traave.20240801.nc"
+  mapping_file = "#expand livvkit_mapping_file_path#/map_r05_to_racmo_gis_566x438_traave.20240801.nc"
   vars = ""
   years = "1985:1994:10"
 

--- a/tests/integration/template_weekly_comprehensive_v3.cfg
+++ b/tests/integration/template_weekly_comprehensive_v3.cfg
@@ -176,6 +176,7 @@ walltime = "00:30:00"
 
 [e3sm_to_cmip]
 active = #expand active_e3sm_to_cmip#
+environment_commands = "#expand e3sm_to_cmip_environment_commands#"
 frequency = "monthly"
 ts_num_years=2
 walltime = "00:30:00"

--- a/tests/integration/template_weekly_legacy_3.0.0_bundles.cfg
+++ b/tests/integration/template_weekly_legacy_3.0.0_bundles.cfg
@@ -99,6 +99,7 @@ years = "1985:1989:2",
 [e3sm_to_cmip]
 active = #expand active_e3sm_to_cmip#
 bundle = "bundle1"
+environment_commands = "#expand e3sm_to_cmip_environment_commands#"
 frequency = "monthly"
 ts_num_years = 2
 years = "1985:1989:2",

--- a/tests/integration/template_weekly_legacy_3.0.0_comprehensive_v2.cfg
+++ b/tests/integration/template_weekly_legacy_3.0.0_comprehensive_v2.cfg
@@ -89,6 +89,7 @@ walltime = "00:30:00"
 
 [e3sm_to_cmip]
 active = #expand active_e3sm_to_cmip#
+environment_commands = "#expand e3sm_to_cmip_environment_commands#"
 frequency = "monthly"
 ts_num_years=2
 walltime = "00:30:00"

--- a/tests/integration/template_weekly_legacy_3.0.0_comprehensive_v3.cfg
+++ b/tests/integration/template_weekly_legacy_3.0.0_comprehensive_v3.cfg
@@ -98,6 +98,7 @@ walltime = "00:30:00"
 
 [e3sm_to_cmip]
 active = #expand active_e3sm_to_cmip#
+environment_commands = "#expand e3sm_to_cmip_environment_commands#"
 frequency = "monthly"
 ts_num_years=2
 walltime = "00:30:00"

--- a/tests/integration/template_weekly_legacy_3.1.0_bundles.cfg
+++ b/tests/integration/template_weekly_legacy_3.1.0_bundles.cfg
@@ -99,6 +99,7 @@ years = "1985:1989:2",
 [e3sm_to_cmip]
 active = #expand active_e3sm_to_cmip#
 bundle = "bundle1"
+environment_commands = "#expand e3sm_to_cmip_environment_commands#"
 frequency = "monthly"
 ts_num_years = 2
 years = "1985:1989:2",

--- a/tests/integration/template_weekly_legacy_3.1.0_comprehensive_v2.cfg
+++ b/tests/integration/template_weekly_legacy_3.1.0_comprehensive_v2.cfg
@@ -89,6 +89,7 @@ walltime = "00:30:00"
 
 [e3sm_to_cmip]
 active = #expand active_e3sm_to_cmip#
+environment_commands = "#expand e3sm_to_cmip_environment_commands#"
 frequency = "monthly"
 ts_num_years=2
 walltime = "00:30:00"

--- a/tests/integration/template_weekly_legacy_3.1.0_comprehensive_v3.cfg
+++ b/tests/integration/template_weekly_legacy_3.1.0_comprehensive_v3.cfg
@@ -100,7 +100,7 @@ walltime = "00:30:00"
 
   [[ atm_monthly_180x360_aave ]]
   cmip_plevdata = "#expand diagnostics_base_path#/e3sm_to_cmip_data/maps/vrt_remap_plev19.nc"
-  cmip_vars = "ua, va, ta, wa, zg, hur, tas, ts, psl, ps, sfcWind, huss, pr, prc, prsn, evspsbl, tauu, tauv, hfls, clt, rlus, rsds, rsus, hfss, clivi, clwvi, rlut, rsdt, rsuscs, rsut, rtmt, abs550aer, od550aer, rsdscs, tasmax, tasmin"
+  cmip_vars = "ua, va, ta, wap, zg, hur, tas, ts, psl, ps, sfcWind, huss, pr, prc, prsn, evspsbl, tauu, tauv, hfls, clt, rlus, rsds, rsus, hfss, clivi, clwvi, rlut, rsdt, rsuscs, rsut, rtmt, abs550aer, od550aer, rsdscs, tasmax, tasmin"
   input_files = "eam.h0"
   ts_subsection = "atm_monthly_180x360_aave"
   vars = "ICEFRAC,LANDFRAC,OCNFRAC,PSL,FSNTC,FSNTOAC,SWCF,LWCF,FLUT,FSNT,FSNTOA,FLNT,FLNTC,FSNS,FLNS,FSNS,SHFLX,QFLX,LHFLX,TAUX,TAUY,PRECC,PRECL,PRECSC,PRECSL,TS,TREFHT,U10,QREFHT,TMQ,CLDTOT,CLDHGH,CLDMED,CLDLOW,FLDS,FSDS,TGCLDIWP,TGCLDCWP,TGCLDLWP,FLNSC,FLUTC,FSDSC,SOLIN,FSNSC,AODABS,AODVIS,AODDUST,AREL,TREFMNAV,TREFMXAV,PS,PHIS,U,V,T,Z3"

--- a/tests/integration/template_weekly_legacy_3.1.0_comprehensive_v3.cfg
+++ b/tests/integration/template_weekly_legacy_3.1.0_comprehensive_v3.cfg
@@ -94,6 +94,7 @@ walltime = "00:30:00"
 
 [e3sm_to_cmip]
 active = #expand active_e3sm_to_cmip#
+environment_commands = "#expand e3sm_to_cmip_environment_commands#"
 frequency = "monthly"
 ts_num_years=2
 walltime = "00:30:00"

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -58,7 +58,7 @@ def get_chyrsalis_expansions(config):
     # Note: `os.environ.get("USER")` also works. Here we're already using mache but not os, so using mache.
     username = config.get("web_portal", "username")
     web_base_path = config.get("web_portal", "base_path")
-    # Not used: diagnostics_base_path = config.get("diagnostics", "base_path")
+    diagnostics_base_path = config.get("diagnostics", "base_path")
     d = {
         "bundles_walltime": "07:00:00",
         "case_name": "v3.LR.historical_0051",
@@ -66,8 +66,7 @@ def get_chyrsalis_expansions(config):
         "constraint": "",
         "diags_walltime": "5:00:00",
         "expected_dir": "/lcrc/group/e3sm/public_html/zppy_test_resources/",
-        "livvkit_mapping_file_path": "/lcrc/group/e3sm/public_html/diagnostics/maps",
-        "livvkit_mapping_file_path_alternative": "/lcrc/group/e3sm/ac.forsyth2/maps",
+        "livvkit_mapping_file_path": f"{diagnostics_base_path}/maps",
         "mpas_analysis_walltime": "00:30:00",
         "partition_long": "compute",
         "partition_short": "debug",
@@ -97,7 +96,6 @@ def get_compy_expansions(config):
         "diags_walltime": "03:00:00",
         "expected_dir": "/compyfs/www/zppy_test_resources/",
         "livvkit_mapping_file_path": f"{diagnostics_base_path}/maps",
-        "livvkit_mapping_file_path_alternative": f"{diagnostics_base_path}/maps",
         "mpas_analysis_walltime": "02:00:00",
         "partition_long": "slurm",
         "partition_short": "short",
@@ -125,7 +123,6 @@ def get_perlmutter_expansions(config):
         "diags_walltime": "6:00:00",
         "expected_dir": "/global/cfs/cdirs/e3sm/www/zppy_test_resources/",
         "livvkit_mapping_file_path": f"{diagnostics_base_path}/maps",
-        "livvkit_mapping_file_path_alternative": f"{diagnostics_base_path}/maps",
         "mpas_analysis_walltime": "03:00:00",
         "partition_long": "",
         "partition_short": "",

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -58,6 +58,7 @@ def get_chyrsalis_expansions(config):
     # Note: `os.environ.get("USER")` also works. Here we're already using mache but not os, so using mache.
     username = config.get("web_portal", "username")
     web_base_path = config.get("web_portal", "base_path")
+    # Not used: diagnostics_base_path = config.get("diagnostics", "base_path")
     d = {
         "bundles_walltime": "07:00:00",
         "case_name": "v3.LR.historical_0051",
@@ -65,6 +66,8 @@ def get_chyrsalis_expansions(config):
         "constraint": "",
         "diags_walltime": "5:00:00",
         "expected_dir": "/lcrc/group/e3sm/public_html/zppy_test_resources/",
+        "livvkit_mapping_file_path": "/lcrc/group/e3sm/public_html/diagnostics/maps",
+        "livvkit_mapping_file_path_alternative": "/lcrc/group/e3sm/ac.forsyth2/maps",
         "mpas_analysis_walltime": "00:30:00",
         "partition_long": "compute",
         "partition_short": "debug",
@@ -85,6 +88,7 @@ def get_chyrsalis_expansions(config):
 def get_compy_expansions(config):
     username = config.get("web_portal", "username")
     web_base_path = config.get("web_portal", "base_path")
+    diagnostics_base_path = config.get("diagnostics", "base_path")
     d = {
         "bundles_walltime": "02:00:00",
         "case_name": "v3.LR.historical_0051",
@@ -92,11 +96,13 @@ def get_compy_expansions(config):
         "constraint": "",
         "diags_walltime": "03:00:00",
         "expected_dir": "/compyfs/www/zppy_test_resources/",
+        "livvkit_mapping_file_path": f"{diagnostics_base_path}/maps",
+        "livvkit_mapping_file_path_alternative": f"{diagnostics_base_path}/maps",
         "mpas_analysis_walltime": "02:00:00",
         "partition_long": "slurm",
         "partition_short": "short",
-        "path_dc_obs_climo": "/compyfs/diagnostics/observations/Atm/climatology/",
-        "path_pcmdi_diags_obs_ts": "/compyfs/diagnostics/observations/Atm/time-series/",
+        "path_dc_obs_climo": f"{diagnostics_base_path}/observations/Atm/climatology/",
+        "path_pcmdi_diags_obs_ts": f"{diagnostics_base_path}/observations/Atm/time-series/",
         "qos_long": "regular",
         "qos_short": "regular",
         "user_input_v2": "/compyfs/fors729/",
@@ -110,6 +116,7 @@ def get_compy_expansions(config):
 def get_perlmutter_expansions(config):
     username = config.get("web_portal", "username")
     web_base_path = config.get("web_portal", "base_path")
+    diagnostics_base_path = config.get("diagnostics", "base_path")
     d = {
         "bundles_walltime": "6:00:00",
         "case_name": "v3.LR.historical_0051",
@@ -117,11 +124,13 @@ def get_perlmutter_expansions(config):
         "constraint": "cpu",
         "diags_walltime": "6:00:00",
         "expected_dir": "/global/cfs/cdirs/e3sm/www/zppy_test_resources/",
+        "livvkit_mapping_file_path": f"{diagnostics_base_path}/maps",
+        "livvkit_mapping_file_path_alternative": f"{diagnostics_base_path}/maps",
         "mpas_analysis_walltime": "03:00:00",
         "partition_long": "",
         "partition_short": "",
-        "path_dc_obs_climo": "/global/cfs/cdirs/e3sm/diagnostics/observations/Atm/climatology/",
-        "path_pcmdi_diags_obs_ts": "/global/cfs/cdirs/e3sm/diagnostics/observations/Atm/time-series/",
+        "path_dc_obs_climo": f"{diagnostics_base_path}/observations/Atm/climatology/",
+        "path_pcmdi_diags_obs_ts": f"{diagnostics_base_path}/observations/Atm/time-series/",
         "qos_long": "regular",
         "qos_short": "regular",  # debug walltime too short?
         # Use CFS for large datasets

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -19,6 +19,7 @@ TEST_SPECIFICS: Dict[str, Any] = {
     # That is, there will be no environment set.
     # (`environment_commands = ""` only redirects to Unified
     # if specified under the [default] task)
+    "e3sm_to_cmip_environment_commands": "source <INSERT PATH TO CONDA>/conda.sh; conda activate <INSERT ENV NAME>",
     "diags_environment_commands": "source <INSERT PATH TO CONDA>/conda.sh; conda activate <INSERT ENV NAME>",
     "mpas_analysis_environment_commands": "source <INSERT PATH TO CONDA>/conda.sh; conda activate <INSERT ENV NAME>",
     "global_time_series_environment_commands": "source <INSERT PATH TO CONDA>/conda.sh; conda activate <INSERT ENV NAME>",
@@ -153,6 +154,9 @@ def get_expansions():
         raise ValueError(f"Unsupported machine={machine}")
 
     # Set up environments
+    expansions["e3sm_to_cmip_environment_commands"] = TEST_SPECIFICS[
+        "e3sm_to_cmip_environment_commands"
+    ]
     expansions["diags_environment_commands"] = TEST_SPECIFICS[
         "diags_environment_commands"
     ]
@@ -329,6 +333,9 @@ def generate_cfgs(dry_run=False):
         substitute_expansions(expansions, script_template, script_generated)
     print("CFG FILES HAVE BEEN GENERATED FROM TEMPLATES WITH THESE SETTINGS:")
     print(f"UNIQUE_ID={TEST_SPECIFICS['unique_id']}")
+    print(
+        f"e3sm_to_cmip_environment_commands={expansions['e3sm_to_cmip_environment_commands']}"
+    )
     print(f"diags_environment_commands={expansions['diags_environment_commands']}")
     print(
         f"mpas_analysis_environment_commands={expansions['mpas_analysis_environment_commands']}"

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -93,7 +93,7 @@ def get_compy_expansions(config):
         "case_name": "v3.LR.historical_0051",
         "case_name_v2": "v2.LR.historical_0201",
         "constraint": "",
-        "diags_walltime": "03:00:00",
+        "diags_walltime": "06:00:00",
         "expected_dir": "/compyfs/www/zppy_test_resources/",
         "livvkit_mapping_file_path": f"{diagnostics_base_path}/maps",
         "mpas_analysis_walltime": "02:00:00",

--- a/zppy/e3sm_to_cmip.py
+++ b/zppy/e3sm_to_cmip.py
@@ -64,7 +64,7 @@ def e3sm_to_cmip(config: ConfigObj, script_dir: str, existing_bundles, job_ids_f
             if c["cmip_vars"] == "":
                 if c["component"] == "atm":
                     c["cmip_vars"] = (
-                        "ua, va, ta, wa, zg, hur, tas, ts, psl, ps, sfcWind, huss, pr, prc, prsn, evspsbl, tauu, tauv, hfls, clt, rlds, rlus, rsds, rsus, hfss, clivi, clwvi, prw, rldscs, rlut, rlutcs, rsdt, rsuscs, rsut, rsutcs, rtmt, abs550aer, od550aer, rsdscs, tasmax, tasmin"
+                        "ua, va, ta, wap, zg, hur, tas, ts, psl, ps, sfcWind, huss, pr, prc, prsn, evspsbl, tauu, tauv, hfls, clt, rlds, rlus, rsds, rsus, hfss, clivi, clwvi, prw, rldscs, rlut, rlutcs, rsdt, rsuscs, rsut, rsutcs, rtmt, abs550aer, od550aer, rsdscs, tasmax, tasmin"
                     )
                 elif c["component"] == "lnd":
                     c["cmip_vars"] = (

--- a/zppy/templates/bundle.bash
+++ b/zppy/templates/bundle.bash
@@ -25,7 +25,7 @@ echo ==============================================
 echo "Elapsed time: $ELAPSEDTIME seconds"
 echo ==============================================
 if [ ${error} = true ]; then
-  echo 'ERROR' > {{ prefix }}.status
+  echo 'ERROR (1)' > {{ prefix }}.status
   exit 1
 else
   rm -f {{ prefix }}.status

--- a/zppy/templates/climo.bash
+++ b/zppy/templates/climo.bash
@@ -5,6 +5,18 @@ set -e
 {{ environment_commands }}
 set +e
 
+# Detect whether to use pixi or conda based on environment_commands
+if echo {{ environment_commands }} | grep -q "conda"; then
+    pkg_manager="conda"
+else
+    pkg_manager="pixi"
+fi
+
+echo "${pkg_manager} list python:"
+${pkg_manager} list python || true # If we can't print this, just continue on.
+echo "${pkg_manager} list nco:"
+${pkg_manager} list nco || true # If we can't print this, just continue on.
+
 # Create temporary workdir
 hash=`mktemp --dry-run -d XXXX`
 workdir=tmp.{{ prefix }}.${id}.${hash}

--- a/zppy/templates/climo.bash
+++ b/zppy/templates/climo.bash
@@ -5,15 +5,7 @@ set -e
 {{ environment_commands }}
 set +e
 
-# Detect whether to use pixi or conda based on environment_commands
-if echo {{ environment_commands }} | grep -q "conda"; then
-    pkg_manager="conda"
-else
-    pkg_manager="pixi"
-fi
-
-echo "${pkg_manager} list python:"
-${pkg_manager} list python || true # If we can't print this, just continue on.
+set_pkg_manager
 echo "${pkg_manager} list nco:"
 ${pkg_manager} list nco || true # If we can't print this, just continue on.
 

--- a/zppy/templates/e3sm_diags.bash
+++ b/zppy/templates/e3sm_diags.bash
@@ -16,6 +16,18 @@ set -e
 {{ environment_commands }}
 set +e
 
+# Detect whether to use pixi or conda based on environment_commands
+if echo {{ environment_commands }} | grep -q "conda"; then
+    pkg_manager="conda"
+else
+    pkg_manager="pixi"
+fi
+
+echo "${pkg_manager} list python:"
+${pkg_manager} list python || true # If we can't print this, just continue on.
+echo "${pkg_manager} list e3sm_diags:"
+${pkg_manager} list e3sm_diags || true # If we can't print this, just continue on.
+
 # Make sure UVCDAT doesn't prompt us about anonymous logging
 export UVCDAT_ANONYMOUS_LOG=False
 

--- a/zppy/templates/e3sm_diags.bash
+++ b/zppy/templates/e3sm_diags.bash
@@ -105,12 +105,12 @@ climo_dir_primary=climo_test
 {%- endif %}
 # Create local links to input climo files
 climo_dir_source={{ output }}/post/atm/{{ grid }}/clim/{{ '%dyr' % (year2-year1+1) }}
-create_links_climo ${climo_dir_source} ${climo_dir_primary} ${case} ${Y1} ${Y2} 1
+create_links_climo ${climo_dir_source} ${climo_dir_primary} ${case} ${Y1} ${Y2} 3
 {% if run_type == "model_vs_model" %}
 # Create local links to input climo files (ref model)
 climo_dir_source={{ reference_data_path }}/{{ '%dyr' % (ref_year2-ref_year1+1) }}
 climo_dir_ref=climo_ref
-create_links_climo ${climo_dir_source} ${climo_dir_ref} {{ ref_name }} ${ref_Y1} ${ref_Y2} 2
+create_links_climo ${climo_dir_source} ${climo_dir_ref} {{ ref_name }} ${ref_Y1} ${ref_Y2} 4
 {%- endif %}
 {%- endif %}
 
@@ -123,12 +123,12 @@ climo_diurnal_dir_primary=climo_{{ climo_diurnal_frequency }}_test
 {%- endif %}
 # Create local links to input diurnal cycle climo files
 climo_diurnal_dir_source={{ output }}/post/atm/{{ grid }}/clim_{{ climo_diurnal_frequency }}/{{ '%dyr' % (year2-year1+1) }}
-create_links_climo_diurnal ${climo_diurnal_dir_source} ${climo_diurnal_dir_primary} ${case} ${Y1} ${Y2} 3
+create_links_climo_diurnal ${climo_diurnal_dir_source} ${climo_diurnal_dir_primary} ${case} ${Y1} ${Y2} 5
 {% if run_type == "model_vs_model" %}
 # Create local links to input climo files (ref model)
 climo_diurnal_dir_source={{ reference_data_path_climo_diurnal }}/{{ '%dyr' % (ref_year2-ref_year1+1) }}
 climo_diurnal_dir_ref=climo_diurnal_ref
-create_links_climo_diurnal ${climo_diurnal_dir_source} ${climo_diurnal_dir_ref} {{ ref_name }} ${ref_Y1} ${ref_Y2} 4
+create_links_climo_diurnal ${climo_diurnal_dir_source} ${climo_diurnal_dir_ref} {{ ref_name }} ${ref_Y1} ${ref_Y2} 6
 {%- endif %}
 {%- endif %}
 
@@ -542,8 +542,8 @@ command="srun -n 1 python -u e3sm.py"
 time ${command}
 if [ $? != 0 ]; then
   cd {{ scriptDir }}
-  echo 'ERROR (9)' > {{ prefix }}.status
-  exit 9
+  echo 'ERROR (7)' > {{ prefix }}.status
+  exit 7
 fi
 
 # Copy output to web server
@@ -556,8 +556,8 @@ web_dir=${www}/${case}/e3sm_diags/{{ sub }}
 mkdir -p ${web_dir}
 if [ $? != 0 ]; then
   cd {{ scriptDir }}
-  echo 'ERROR (10)' > {{ prefix }}.status
-  exit 10
+  echo 'ERROR (8)' > {{ prefix }}.status
+  exit 8
 fi
 
 {% if machine in ['pm-cpu', 'pm-gpu'] %}
@@ -578,8 +578,8 @@ done
 rsync -a --delete ${results_dir} ${web_dir}/
 if [ $? != 0 ]; then
   cd {{ scriptDir }}
-  echo 'ERROR (11)' > {{ prefix }}.status
-  exit 11
+  echo 'ERROR (9)' > {{ prefix }}.status
+  exit 9
 fi
 
 {% if machine in ['pm-cpu', 'pm-gpu'] %}

--- a/zppy/templates/e3sm_diags.bash
+++ b/zppy/templates/e3sm_diags.bash
@@ -16,15 +16,7 @@ set -e
 {{ environment_commands }}
 set +e
 
-# Detect whether to use pixi or conda based on environment_commands
-if echo {{ environment_commands }} | grep -q "conda"; then
-    pkg_manager="conda"
-else
-    pkg_manager="pixi"
-fi
-
-echo "${pkg_manager} list python:"
-${pkg_manager} list python || true # If we can't print this, just continue on.
+set_pkg_manager
 echo "${pkg_manager} list e3sm_diags:"
 ${pkg_manager} list e3sm_diags || true # If we can't print this, just continue on.
 

--- a/zppy/templates/e3sm_to_cmip.bash
+++ b/zppy/templates/e3sm_to_cmip.bash
@@ -5,15 +5,7 @@ set -e
 {{ environment_commands }}
 set +e
 
-# Detect whether to use pixi or conda based on environment_commands
-if echo {{ environment_commands }} | grep -q "conda"; then
-    pkg_manager="conda"
-else
-    pkg_manager="pixi"
-fi
-
-echo "${pkg_manager} list python:"
-${pkg_manager} list python || true # If we can't print this, just continue on.
+set_pkg_manager
 echo "${pkg_manager} list e3sm_to_cmip:"
 ${pkg_manager} list e3sm_to_cmip || true # If we can't print this, just continue on.
 

--- a/zppy/templates/e3sm_to_cmip.bash
+++ b/zppy/templates/e3sm_to_cmip.bash
@@ -5,6 +5,18 @@ set -e
 {{ environment_commands }}
 set +e
 
+# Detect whether to use pixi or conda based on environment_commands
+if echo {{ environment_commands }} | grep -q "conda"; then
+    pkg_manager="conda"
+else
+    pkg_manager="pixi"
+fi
+
+echo "${pkg_manager} list python:"
+${pkg_manager} list python || true # If we can't print this, just continue on.
+echo "${pkg_manager} list e3sm_to_cmip:"
+${pkg_manager} list e3sm_to_cmip || true # If we can't print this, just continue on.
+
 # Create temporary workdir
 hash=`mktemp --dry-run -d XXXX`
 workdir=tmp.{{ prefix }}.${id}.${hash}

--- a/zppy/templates/global_time_series.bash
+++ b/zppy/templates/global_time_series.bash
@@ -5,15 +5,7 @@ set -e
 {{ environment_commands }}
 set +e
 
-# Detect whether to use pixi or conda based on environment_commands
-if echo {{ environment_commands }} | grep -q "conda"; then
-    pkg_manager="conda"
-else
-    pkg_manager="pixi"
-fi
-
-echo "${pkg_manager} list python:"
-${pkg_manager} list python || true # If we can't print this, just continue on.
+set_pkg_manager
 echo "${pkg_manager} list zppy-interfaces:"
 ${pkg_manager} list zppy-interfaces || true # If we can't print this, just continue on.
 

--- a/zppy/templates/global_time_series.bash
+++ b/zppy/templates/global_time_series.bash
@@ -10,7 +10,11 @@ set +e
 
 results_dir={{ prefix }}_results
 zi-global-time-series --use_ocn {{ use_ocn }} --input {{ input }} --input_subdir {{ input_subdir }} --moc_file {{ moc_file }} --case_dir {{ output }} --experiment_name {{ experiment_name }} --figstr {{ figstr }} --color {{ color }} --ts_num_years {{ ts_num_years }} --plots_original {{ plots_original }} --plots_atm {{ plots_atm }} --plots_ice {{ plots_ice }} --plots_lnd {{ plots_lnd }} --plots_ocn {{ plots_ocn }} --nrows {{ nrows }} --ncols {{ ncols }} --results_dir ${results_dir} --regions {{ regions }} --make_viewer {{ make_viewer }} --start_yr {{ year1 }} --end_yr {{ year2 }}
-
+if [ $? != 0 ]; then
+    cd {{ scriptDir }}
+    echo 'ERROR (1)' > {{ prefix }}.status
+    exit 1
+fi
 
 
 results_dir_absolute_path={{ scriptDir }}/${results_dir}
@@ -31,8 +35,8 @@ if [ -d "${results_dir_absolute_path}/ocn" ]; then
     rsync -av ${results_dir_absolute_path}/ocn/ ${case_dir}/post/ocn/
     if [ $? != 0 ]; then
         cd {{ scriptDir }}
-        echo 'ERROR (6)' > {{ prefix }}.status
-        exit 6
+        echo 'ERROR (2)' > {{ prefix }}.status
+        exit 2
     fi
     echo "Ocean results copied to ${case_dir}/post/ocn/"
 else
@@ -50,8 +54,8 @@ results_level=${top_level}/${results_dir}
 mkdir -p ${results_level}
 if [ $? != 0 ]; then
   cd {{ scriptDir }}
-  echo 'ERROR (7)' > {{ prefix }}.status
-  exit 7
+  echo 'ERROR (3)' > {{ prefix }}.status
+  exit 3
 fi
 
 {% if machine in ['pm-cpu', 'pm-gpu'] %}
@@ -72,8 +76,8 @@ done
 rsync -a --delete --exclude='ocn' ${results_dir_absolute_path} ${top_level}
 if [ $? != 0 ]; then
   cd {{ scriptDir }}
-  echo 'ERROR (8)' > {{ prefix }}.status
-  exit 8
+  echo 'ERROR (4)' > {{ prefix }}.status
+  exit 4
 fi
 
 {% if machine in ['pm-cpu', 'pm-gpu'] %}

--- a/zppy/templates/global_time_series.bash
+++ b/zppy/templates/global_time_series.bash
@@ -5,6 +5,18 @@ set -e
 {{ environment_commands }}
 set +e
 
+# Detect whether to use pixi or conda based on environment_commands
+if echo {{ environment_commands }} | grep -q "conda"; then
+    pkg_manager="conda"
+else
+    pkg_manager="pixi"
+fi
+
+echo "${pkg_manager} list python:"
+${pkg_manager} list python || true # If we can't print this, just continue on.
+echo "${pkg_manager} list zppy-interfaces:"
+${pkg_manager} list zppy-interfaces || true # If we can't print this, just continue on.
+
 # Generate global time series plots
 ################################################################################
 

--- a/zppy/templates/ilamb.bash
+++ b/zppy/templates/ilamb.bash
@@ -5,15 +5,7 @@ set -e
 {{ environment_commands }}
 set +e
 
-# Detect whether to use pixi or conda based on environment_commands
-if echo {{ environment_commands }} | grep -q "conda"; then
-    pkg_manager="conda"
-else
-    pkg_manager="pixi"
-fi
-
-echo "${pkg_manager} list python:"
-${pkg_manager} list python || true # If we can't print this, just continue on.
+set_pkg_manager
 echo "${pkg_manager} list ilamb:"
 ${pkg_manager} list ilamb || true # If we can't print this, just continue on.
 

--- a/zppy/templates/ilamb.bash
+++ b/zppy/templates/ilamb.bash
@@ -5,6 +5,18 @@ set -e
 {{ environment_commands }}
 set +e
 
+# Detect whether to use pixi or conda based on environment_commands
+if echo {{ environment_commands }} | grep -q "conda"; then
+    pkg_manager="conda"
+else
+    pkg_manager="pixi"
+fi
+
+echo "${pkg_manager} list python:"
+${pkg_manager} list python || true # If we can't print this, just continue on.
+echo "${pkg_manager} list ilamb:"
+${pkg_manager} list ilamb || true # If we can't print this, just continue on.
+
 # Point to observation data
 export ILAMB_ROOT={{ ilamb_obs }}
 

--- a/zppy/templates/inclusions/boilerplate.bash
+++ b/zppy/templates/inclusions/boilerplate.bash
@@ -13,3 +13,18 @@ id=${SLURM_JOBID}
 # Update status file
 STARTTIME=$(date +%s)
 echo "RUNNING ${id}" > {{ prefix }}.status
+
+set_pkg_manager() {
+  # Detect whether to use pixi or conda based on environment_commands
+  # Important: we need the quotes since environment_commands might
+  # include multiple commands, separated by semi-colon.
+  if echo "{{ environment_commands }}" | grep -q "conda"; then
+      pkg_manager="conda"
+  else
+      pkg_manager="pixi"
+  fi
+
+  # We always want to know what the python version is.
+  echo "${pkg_manager} list python:"
+  ${pkg_manager} list python || true # If we can't print this, just continue on.
+}

--- a/zppy/templates/livvkit.bash
+++ b/zppy/templates/livvkit.bash
@@ -8,15 +8,7 @@ set -e
 {{ environment_commands }}
 set +e
 
-# Detect whether to use pixi or conda based on environment_commands
-if echo {{ environment_commands }} | grep -q "conda"; then
-    pkg_manager="conda"
-else
-    pkg_manager="pixi"
-fi
-
-echo "${pkg_manager} list python:"
-${pkg_manager} list python || true # If we can't print this, just continue on.
+set_pkg_manager
 echo "${pkg_manager} list livvkit:"
 ${pkg_manager} list livvkit || true # If we can't print this, just continue on.
 

--- a/zppy/templates/livvkit.bash
+++ b/zppy/templates/livvkit.bash
@@ -51,8 +51,8 @@ livv --validate livvkit.yml --out-dir ./${case}.web
 
 if [ $? != 0 ]; then
   cd {{ scriptDir }}
-  echo 'ERROR (3)' > {{ prefix }}.status
-  exit 3
+  echo 'ERROR (1)' > {{ prefix }}.status
+  exit 1
 fi
 mv livv_log_${case}.web.log ./${case}.web/logs
 
@@ -66,8 +66,8 @@ web_dir=${www}/${case}/livvkit/${Y1}-${Y2}
 mkdir -p ${web_dir}
 if [ $? != 0 ]; then
   cd {{ scriptDir }}
-  echo 'ERROR (4)' > {{ prefix }}.status
-  exit 4
+  echo 'ERROR (2)' > {{ prefix }}.status
+  exit 2
 fi
 
 {% if machine in ['pm-cpu', 'pm-gpu'] %}
@@ -89,8 +89,8 @@ results_dir=./${case}.web/
 rsync -a --delete ${results_dir} ${web_dir}/
 if [ $? != 0 ]; then
   cd {{ scriptDir }}
-  echo 'ERROR (5)' > {{ prefix }}.status
-  exit 5
+  echo 'ERROR (3)' > {{ prefix }}.status
+  exit 3
 fi
 
 {% if machine in ['pm-cpu', 'pm-gpu'] %}

--- a/zppy/templates/livvkit.bash
+++ b/zppy/templates/livvkit.bash
@@ -8,6 +8,18 @@ set -e
 {{ environment_commands }}
 set +e
 
+# Detect whether to use pixi or conda based on environment_commands
+if echo {{ environment_commands }} | grep -q "conda"; then
+    pkg_manager="conda"
+else
+    pkg_manager="pixi"
+fi
+
+echo "${pkg_manager} list python:"
+${pkg_manager} list python || true # If we can't print this, just continue on.
+echo "${pkg_manager} list livvkit:"
+${pkg_manager} list livvkit || true # If we can't print this, just continue on.
+
 # Basic definitions
 case="{{ case }}"
 short="{{ short_name }}"

--- a/zppy/templates/mpas_analysis.bash
+++ b/zppy/templates/mpas_analysis.bash
@@ -5,6 +5,18 @@ set -e
 {{ environment_commands }}
 set +e
 
+# Detect whether to use pixi or conda based on environment_commands
+if echo {{ environment_commands }} | grep -q "conda"; then
+    pkg_manager="conda"
+else
+    pkg_manager="pixi"
+fi
+
+echo "${pkg_manager} list python:"
+${pkg_manager} list python || true # If we can't print this, just continue on.
+echo "${pkg_manager} list mpas-analysis:"
+${pkg_manager} list mpas-analysis || true # If we can't print this, just continue on.
+
 # Additional settings for MPAS-Analysis
 export OMP_NUM_THREADS=1
 export HDF5_USE_FILE_LOCKING=FALSE

--- a/zppy/templates/mpas_analysis.bash
+++ b/zppy/templates/mpas_analysis.bash
@@ -5,15 +5,7 @@ set -e
 {{ environment_commands }}
 set +e
 
-# Detect whether to use pixi or conda based on environment_commands
-if echo {{ environment_commands }} | grep -q "conda"; then
-    pkg_manager="conda"
-else
-    pkg_manager="pixi"
-fi
-
-echo "${pkg_manager} list python:"
-${pkg_manager} list python || true # If we can't print this, just continue on.
+set_pkg_manager
 echo "${pkg_manager} list mpas-analysis:"
 ${pkg_manager} list mpas-analysis || true # If we can't print this, just continue on.
 

--- a/zppy/templates/pcmdi_diags.bash
+++ b/zppy/templates/pcmdi_diags.bash
@@ -5,6 +5,20 @@ set -e
 {{ environment_commands }}
 set +e
 
+# Detect whether to use pixi or conda based on environment_commands
+if echo {{ environment_commands }} | grep -q "conda"; then
+    pkg_manager="conda"
+else
+    pkg_manager="pixi"
+fi
+
+echo "${pkg_manager} list python:"
+${pkg_manager} list python || true # If we can't print this, just continue on.
+echo "${pkg_manager} list zppy-interfaces:"
+${pkg_manager} list zppy-interfaces || true # If we can't print this, just continue on.
+echo "${pkg_manager} list pcmdi_metrics:"
+${pkg_manager} list pcmdi_metrics || true # If we can't print this, just continue on.
+
 # Turn on debug output if needed
 debug={{ debug }}
 if [[ "${debug,,}" == "true" ]]; then

--- a/zppy/templates/pcmdi_diags.bash
+++ b/zppy/templates/pcmdi_diags.bash
@@ -523,8 +523,8 @@ time eval "${command}"
 
 if [ $? -ne 0 ]; then
   cd {{ scriptDir }}
-  echo "ERROR (6)" > {{ prefix }}.status
-  exit 6
+  echo "ERROR (5)" > {{ prefix }}.status
+  exit 5
 fi
 
 set -e
@@ -539,10 +539,10 @@ ts_dir_ref_source="{{ scriptDir }}/${workdir}/${obstmp_dir}"
 
 {% if current_set == "mean_climate" %}
 climo_dir_ref=climo_ref
-create_links_acyc_climo_obs "${ts_dir_ref_source}" "${climo_dir_ref}" ${ref_Y1} ${ref_Y2} 7
+create_links_acyc_climo_obs "${ts_dir_ref_source}" "${climo_dir_ref}" ${ref_Y1} ${ref_Y2} 6
 {% elif current_set in ["variability_modes_cpl", "variability_modes_atm", "enso"] %}
 ts_dir_ref=ts_ref
-create_links_ts_obs "${ts_dir_ref_source}" "${ts_dir_ref}" ${ref_Y1} ${ref_Y2} 8
+create_links_ts_obs "${ts_dir_ref_source}" "${ts_dir_ref}" ${ref_Y1} ${ref_Y2} 7
 {% endif %}
 
 {% endif %}
@@ -908,8 +908,8 @@ echo "The current directory is: $PWD" # This will be of the form .../post/script
 time ${command}
 if [ $? != 0 ]; then
   cd {{ scriptDir }}
-  echo 'ERROR (11)' > {{ prefix }}.status
-  exit 11
+  echo 'ERROR (8)' > {{ prefix }}.status
+  exit 8
 fi
 
 set -e
@@ -926,8 +926,8 @@ echo
 mkdir -p ${web_dir}
 if [ $? != 0 ]; then
   cd {{ scriptDir }}
-  echo 'ERROR (13)' > {{ prefix }}.status
-  exit 13
+  echo 'ERROR (9)' > {{ prefix }}.status
+  exit 9
 fi
 
 {% if machine in ['pm-cpu', 'pm-gpu'] %}
@@ -951,8 +951,8 @@ done
 rsync -a ${results_dir} ${web_dir}/
 if [ $? != 0 ]; then
   cd {{ scriptDir }}
-  echo 'ERROR (14)' > {{ prefix }}.status
-  exit 14
+  echo 'ERROR (10)' > {{ prefix }}.status
+  exit 10
 fi
 {% endif %}
 

--- a/zppy/templates/pcmdi_diags.bash
+++ b/zppy/templates/pcmdi_diags.bash
@@ -5,15 +5,7 @@ set -e
 {{ environment_commands }}
 set +e
 
-# Detect whether to use pixi or conda based on environment_commands
-if echo {{ environment_commands }} | grep -q "conda"; then
-    pkg_manager="conda"
-else
-    pkg_manager="pixi"
-fi
-
-echo "${pkg_manager} list python:"
-${pkg_manager} list python || true # If we can't print this, just continue on.
+set_pkg_manager
 echo "${pkg_manager} list zppy-interfaces:"
 ${pkg_manager} list zppy-interfaces || true # If we can't print this, just continue on.
 echo "${pkg_manager} list pcmdi_metrics:"

--- a/zppy/templates/tc_analysis.bash
+++ b/zppy/templates/tc_analysis.bash
@@ -5,15 +5,7 @@ set -e # Stop running script on error.
 # This means we don't make as much use of the ERROR > status blocks in this file.
 {{ environment_commands }}
 
-# Detect whether to use pixi or conda based on environment_commands
-if echo {{ environment_commands }} | grep -q "conda"; then
-    pkg_manager="conda"
-else
-    pkg_manager="pixi"
-fi
-
-echo "${pkg_manager} list python:"
-${pkg_manager} list python || true # If we can't print this, just continue on.
+set_pkg_manager
 
 # A Bash script to post-process E3SM 6 hourly (h2) instantaneous output to generate a text file storing Tropical Cyclone tracks
 # tempestremap and tempestextremes are built in e3sm-unified from version 1.5.0.

--- a/zppy/templates/tc_analysis.bash
+++ b/zppy/templates/tc_analysis.bash
@@ -4,6 +4,16 @@
 set -e # Stop running script on error
 {{ environment_commands }}
 
+# Detect whether to use pixi or conda based on environment_commands
+if echo {{ environment_commands }} | grep -q "conda"; then
+    pkg_manager="conda"
+else
+    pkg_manager="pixi"
+fi
+
+echo "${pkg_manager} list python:"
+${pkg_manager} list python || true # If we can't print this, just continue on.
+
 # A Bash script to post-process E3SM 6 hourly (h2) instantaneous output to generate a text file storing Tropical Cyclone tracks
 # tempestremap and tempestextremes are built in e3sm-unified from version 1.5.0.
 

--- a/zppy/templates/tc_analysis.bash
+++ b/zppy/templates/tc_analysis.bash
@@ -1,7 +1,8 @@
 #!/bin/bash
 {% include 'inclusions/slurm_header.bash' %}
 {% include 'inclusions/boilerplate.bash' %}
-set -e # Stop running script on error
+set -e # Stop running script on error.
+# This means we don't make as much use of the ERROR > status blocks in this file.
 {{ environment_commands }}
 
 # Detect whether to use pixi or conda based on environment_commands
@@ -90,16 +91,20 @@ file_name=${caseid}_${start}_${end}
 if $pg2; then
     # For v2 and v3 production simulation with pg2 grids:
     GenerateCSMesh --res $res --alt --file ${result_dir}outCSMeshne$res.g
+    echo "Completed GenerateCSMesh"
     GenerateVolumetricMesh --in ${result_dir}outCSMeshne$res.g  --out ${result_dir}outCSne$res.g --np 2 --uniform
+    echo "Completed GenerateVolumetricMesh"
     out_type="FV"
 else
     # For v1 production simulation with np4 grids:
     GenerateCSMesh --res $res --alt --file ${result_dir}outCSne$res.g
+    echo "Completed GenerateCSMesh"
     out_type="CGLL"
 fi
 echo $out_type
 # Generate connectivity files (.dat)
 GenerateConnectivityFile --in_mesh ${result_dir}outCSne$res.g --out_type $out_type --out_connect ${result_dir}connect_CSne${res}_v2.dat
+echo "Completed GenerateConnectivityFile"
 
 # Get the list of files
 cd ${drc_in};eval ls ${drc_in}/${caseid}.$input_files.*{${start}..${end}}*.nc >${result_dir}inputfile_${file_name}.txt
@@ -111,9 +116,11 @@ cd ${result_dir}
 if [ $res == 120 ]; then
     echo $res
     DetectNodes --verbosity 0 --in_connect ${result_dir}connect_CSne${res}_v2.dat --closedcontourcmd "PSL,300.0,4.0,0;_AVG(T200,T500),-0.6,4,0.30" --mergedist 6.0 --searchbymin PSL --outputcmd "PSL,min,0;_VECMAG(UBOT,VBOT),max,2" --timestride 1 --in_data_list ${result_dir}inputfile_${file_name}.txt --out ${result_dir}out.dat
+    echo "Completed DetectNodes"
 elif [ $res == 30 ]; then
     echo $res
     DetectNodes --verbosity 0 --in_connect ${result_dir}connect_CSne${res}_v2.dat --closedcontourcmd "PSL,300.0,4.0,0;_AVG(T200,T500),-0.6,4,1.0" --mergedist 6.0 --searchbymin PSL --outputcmd "PSL,min,0;_VECMAG(UBOT,VBOT),max,2" --timestride 1 --in_data_list ${result_dir}inputfile_${file_name}.txt --out ${result_dir}out.dat
+    echo "Completed DetectNodes"
 else
     echo “$res value not supported”
 fi
@@ -123,22 +130,28 @@ cat ${result_dir}out.dat0* > ${result_dir}cyclones_${file_name}.txt
 
 # Stitch all candidate nodes in time to form tracks, with a maximum distance between candidates of 6.0, minimum time steps of 6, and with a maximum gap size of one (most consecutive time steps with no associated candidate). And there is threshold for wind speed, lat and lon.
 StitchNodes --in_fmt "lon,lat,slp,wind" --in_connect ${result_dir}connect_CSne${res}_v2.dat --range 6.0 --mintime 6 --maxgap 1 --in ${result_dir}cyclones_${file_name}.txt --out ${result_dir}cyclones_stitch_${file_name}.dat --threshold "wind,>=,17.5,6;lat,<=,40.0,6;lat,>=,-40.0,6"
+echo "Completed StitchNodes"
 rm ${result_dir}cyclones_${file_name}.txt
 
 # Generate histogram of detections
 HistogramNodes --in ${result_dir}cyclones_stitch_${file_name}.dat --iloncol 2 --ilatcol 3 --out ${result_dir}cyclones_hist_${file_name}.nc
+echo "Completed HistogramNodes"
 
 # Calculate relative vorticity
 sed -i 's/\.nc/_vorticity.nc/' ${result_dir}outputfile_${file_name}.txt
 VariableProcessor --in_data_list ${result_dir}inputfile_${file_name}.txt --out_data_list ${result_dir}outputfile_${file_name}.txt --var "_CURL{4,0.5}(U850,V850)" --varout "VORT" --in_connect ${result_dir}connect_CSne${res}_v2.dat
+echo "Completed VariableProcessor"
 
 DetectNodes --verbosity 0 --in_connect ${result_dir}connect_CSne${res}_v2.dat --closedcontourcmd "VORT,-5.e-6,4,0" --mergedist 2.0 --searchbymax VORT --outputcmd "VORT,max,0" --in_data_list ${result_dir}outputfile_${file_name}.txt --out ${result_dir}aew_out.dat --minlat -35.0 --maxlat 35.0
+echo "Completed DetectNodes"
 cat ${result_dir}aew_out.dat0* > ${result_dir}aew_${file_name}.txt
 
 StitchNodes --in_fmt "lon,lat,VORT" --in_connect ${result_dir}connect_CSne${res}_v2.dat --range 3.0 --minlength 8 --maxgap 0 --min_endpoint_dist 10.0 --in ${result_dir}aew_${file_name}.txt --out ${result_dir}aew_stitch_5e-6_${file_name}.dat --threshold "lat,<=,25.0,8;lat,>=,0.0,8"
+echo "Completed StitchNodes"
 rm ${result_dir}aew_${file_name}.txt
 
 HistogramNodes --in ${result_dir}aew_stitch_5e-6_${file_name}.dat --iloncol 2 --ilatcol 3 --nlat 256 --nlon 512 --out ${result_dir}aew_hist_${file_name}.nc
+echo "Completed HistogramNodes"
 
 rm ${result_dir}*out.dat00*.dat
 rm ${result_dir}${caseid}*.nc

--- a/zppy/templates/ts.bash
+++ b/zppy/templates/ts.bash
@@ -5,6 +5,18 @@ set -e
 {{ environment_commands }}
 set +e
 
+# Detect whether to use pixi or conda based on environment_commands
+if echo {{ environment_commands }} | grep -q "conda"; then
+    pkg_manager="conda"
+else
+    pkg_manager="pixi"
+fi
+
+echo "${pkg_manager} list python:"
+${pkg_manager} list python || true # If we can't print this, just continue on.
+echo "${pkg_manager} list nco:"
+${pkg_manager} list nco || true # If we can't print this, just continue on.
+
 # Create temporary workdir
 hash=`mktemp --dry-run -d XXXX`
 workdir=tmp.{{ prefix }}.${id}.${hash}

--- a/zppy/templates/ts.bash
+++ b/zppy/templates/ts.bash
@@ -5,15 +5,7 @@ set -e
 {{ environment_commands }}
 set +e
 
-# Detect whether to use pixi or conda based on environment_commands
-if echo {{ environment_commands }} | grep -q "conda"; then
-    pkg_manager="conda"
-else
-    pkg_manager="pixi"
-fi
-
-echo "${pkg_manager} list python:"
-${pkg_manager} list python || true # If we can't print this, just continue on.
+set_pkg_manager
 echo "${pkg_manager} list nco:"
 ${pkg_manager} list nco || true # If we can't print this, just continue on.
 


### PR DESCRIPTION
## Summary

Objectives:
- Addressing issues in Unified 1.13.0rc4
  - Commit 1: Fix error codes to use logical number sequence (and include one after the `zi-global-time-series` call)
  - Commits 2-4: Standardizing mapping file paths
- Addressing issues in Unified 1.13.0rc5
  - Commits 5 & 10: Log the package version
  - Commit 6: Add more status logging to `tc_analysis`
  - Commit 7: Increase diags walltime on Compy
  - Commit 8: Fix to variables feeding into `e3sm_to_cmip`
  - Commit 9: Add ability to test arbitrary/developer version of `e3sm_to_cmip`

Issue resolution:
- Resolves issues encountered during:
  - [Compy test of E3SM Unified 1.13.0rc4](https://github.com/E3SM-Project/zppy/discussions/802#discussioncomment-16508424)
  - [Compy test of E3SM Unified 1.13.0rc5](https://github.com/E3SM-Project/zppy/discussions/802#discussioncomment-16560117)
  - [Compy follow-up limited test](https://github.com/E3SM-Project/zppy/discussions/802#discussioncomment-16577319)
  - [Perlmutter follow-up limited test](https://github.com/E3SM-Project/zppy/discussions/802#discussioncomment-16607020)

Select one: This pull request is...
- [x] a bug fix: increment the patch version
- [ ] a small improvement: increment the minor version
- [ ] a new feature: increment the minor version
- [ ] an incompatible (non-backwards compatible) API change: increment the major version

## Small Change

- [ ] To merge, I will use "Squash and merge". That is, this change should be a single commit.
   - However, I will use a merge commit since each commit does clearly distinct work.
- [x] Logic: I have visually inspected the entire pull request myself.
- [x] Pre-commit checks: All the pre-commits checks have passed.