### PR TITLE
Fix image checker

### DIFF
--- a/tests/integration/image_checker.py
+++ b/tests/integration/image_checker.py
@@ -256,6 +256,10 @@ def _compare_actual_and_expected(
     except FileNotFoundError:
         missing_images.append(image_name)
         return
+    except Exception as e:
+        print(f"Warning: could not open actual image {path_to_actual_png}: {e}")
+        missing_images.append(image_name)
+        return
     expected_png = Image.open(path_to_expected_png).convert("RGB")
     diff = ImageChops.difference(actual_png, expected_png)
 


### PR DESCRIPTION
## Summary

Objectives:
- Commit 1: fix image checker to handle more exceptions

Issue resolution:
- Resolves issue noted on the [2026-05-08 Chrysalis E3SM Unified 1.13.0rc10 (zppy v3.2.0rc2) results](https://github.com/E3SM-Project/zppy/discussions/802#discussioncomment-16858453). Note this issue wasn't encountered on the Perlmutter or Compy tests because an exception wasn't raised during testing on those machines.

Select one: This pull request is...
- [x] a bug fix: increment the patch version
- [ ] a small improvement: increment the minor version
- [ ] a new feature: increment the minor version
- [ ] an incompatible (non-backwards compatible) API change: increment the major version

## Small Change

- [x] To merge, I will use "Squash and merge". That is, this change should be a single commit.
- [x] Logic: I have visually inspected the entire pull request myself.
- [x] Pre-commit checks: All the pre-commits checks have passed.