### PR TITLE
Draft code to enable mpas ocean/seaice time series processing with re…

### DIFF
--- a/zppy/defaults/default.ini
+++ b/zppy/defaults/default.ini
@@ -151,6 +151,15 @@ job_nbr = integer(default=0)
 tpd = integer(default=1)
 # Model component having generated input files (eam, eamxx, elm, mosart, ...)
 input_component = string(default="")
+# MPAS calendar used to construct a CF-style numeric time coordinate
+# from timeMonthly_avg_daysSinceStartOfSim when native MPAS time-series
+# files do not contain a standard time variable.
+mpas_calendar = string(default="noleap")
+# MPAS simulation start time used as the reference time for constructing
+# a CF-style numeric time coordinate:
+# time:units = "days since <mpas_start_time>"
+# This should match the MPAS/E3SM config_start_time when possible.
+mpas_start_time = string(default="0001-01-01 00:00:00")
 
   [[__many__]]
   area_nm = string(default=None)
@@ -159,6 +168,8 @@ input_component = string(default="")
   job_nbr = integer(default=None)
   tpd = integer(default=None)
   input_component = string(default=None)
+  mpas_calendar = string(default=None)
+  mpas_start_time = string(default=None)
 
 [e3sm_to_cmip]
 # Metadata json file

--- a/zppy/templates/ts.bash
+++ b/zppy/templates/ts.bash
@@ -54,7 +54,7 @@ vars={{ vars }}
 # https://unix.stackexchange.com/questions/237297/the-fastest-way-to-remove-a-string-in-a-variable
 # https://stackoverflow.com/questions/26457052/remove-a-substring-from-a-bash-variable
 # Remove U, since it is a 3D variable and thus will not work with rgn_avg
-vars=${vars//,U}
+# vars=${vars//,U}
 {%- else %}
 vars={{ vars }}
 {%- endif %}
@@ -66,7 +66,7 @@ if grep -q "*" input.txt; then
   echo 'ERROR (1)' > {{ prefix }}.status
   exit 1
 fi
-# Generate time series files
+# Generate time series files.
 # If the user-defined parameter "vars" is "", then ${vars}, defined above, will be too.
 cat input.txt | run_nco ncclimo \
 -c {{ case }} \
@@ -86,16 +86,20 @@ cat input.txt | run_nco ncclimo \
 --yr_srt={{ yr_start }} \
 --yr_end={{ yr_end }} \
 --ypf={{ ypf }} \
-{% if mapping_file == '' -%}
+{%- if mapping_file == '' %}
 -o output \
-{%- elif mapping_file == 'glb' -%}
+{%- elif mapping_file == 'glb' %}
 -o output \
 --rgn_avg \
 --area={{ area_nm }} \
-{%- else -%}
+{%- else %}
+{%- if prc_typ in ['mpasocean', 'mpasseaice'] %}
+-o trash \
+{%- else %}
 --map={{ mapping_file }} \
 -o trash \
 -O output \
+{%- endif %}
 {%- endif %}
 {%- if frequency != 'monthly' %}
 --clm_md=hfs \
@@ -104,13 +108,261 @@ cat input.txt | run_nco ncclimo \
 {%- endif %}
 --prc_typ={{ prc_typ }}
 
-
-
+# Check ncclimo status before any optional separate regridding.
 if [ $? != 0 ]; then
   cd {{ scriptDir }}
   echo 'ERROR (2)' > {{ prefix }}.status
   exit 2
 fi
+
+{%- if mapping_file != '' and mapping_file != 'glb' and prc_typ in ['mpasocean', 'mpasseaice'] %}
+
+# Regrid MPAS-Ocean and MPAS-Seaice files separately.
+#
+# For MPAS components, generate native-grid time-series files first, then
+# regrid them with ncremap. This lets us restore MPAS-native time metadata,
+# construct a CF-style numeric time coordinate, and repair missing_value
+# attributes after regridding if needed.
+#
+# For MPAS-Seaice, also provide valid spatial-only SGS helper variables for
+# regridding. MPAS-Seaice monthly files may include time-dependent SGS
+# diagnostics such as:
+#
+#   timeMonthly_avg_iceAreaCell(Time,nCells)
+#
+# This variable should remain in the final time-series output. However,
+# NCO's regridder requires sgs_frc_nm and sgs_msk_nm to be spatial-only
+# fields matching the horizontal source grid size, i.e., nCells. Therefore,
+# create temporary spatial-only helper variables with separate names and use
+# them only for regridding.
+mkdir -p output
+
+mpas_calendar="{{ mpas_calendar }}"
+mpas_start_time="{{ mpas_start_time }}"
+mpas_start_time="${mpas_start_time/_/ }"
+
+for f in trash/*.nc ; do
+  bname=$(basename "${f}")
+  tmp_f="tmp_regrid_${bname}"
+  tmp_frc="tmp_sgs_frc_${bname}"
+  tmp_msk="tmp_sgs_msk_${bname}"
+  out_f="output/${bname}"
+
+  cp "${f}" "${tmp_f}"
+
+  # Detect whether the time dimension is named Time or time.
+  # MPAS native ncclimo files often have a Time dimension but no
+  # coordinate variable named Time/time.
+  if run_nco ncks -m "${tmp_f}" | grep -qE "^[[:space:]]*Time[[:space:]]*=|\(Time[,)]|, Time[,)]"; then
+    time_dim="Time"
+  elif run_nco ncks -m "${tmp_f}" | grep -qE "^[[:space:]]*time[[:space:]]*=|\(time[,)]|, time[,)]"; then
+    time_dim="time"
+  else
+    echo "ERROR: Cannot find Time/time dimension in ${tmp_f}"
+    cd {{ scriptDir }}
+    echo 'ERROR (3)' > {{ prefix }}.status
+    exit 3
+  fi
+
+  # Infer the main variable name from the output filename.
+  # Example:
+  #   timeMonthly_avg_seaSurfaceTemperature_000101_000512.nc
+  # becomes:
+  #   timeMonthly_avg_seaSurfaceTemperature
+  main_var=$(echo "${bname}" | sed -E 's/_[0-9]{6}_[0-9]{6}\.nc$//')
+
+  use_sgs_helpers="false"
+
+  {%- if prc_typ == 'mpasseaice' %}
+
+  # Construct explicit static SGS helpers for MPAS-Seaice.
+  #
+  # ncremap -P mpasseaice automatically tries to use
+  # timeMonthly_avg_iceAreaCell as sgs_frc_nm. However, that variable is
+  # time-dependent, with shape Time x nCells, while NCO requires sgs_frc_nm
+  # to be spatial-only, with shape nCells.
+  #
+  # Therefore, whenever timeMonthly_avg_iceAreaCell is available, construct:
+  #
+  #   sgs_frc_static(nCells) = time mean of timeMonthly_avg_iceAreaCell
+  #   sgs_msk_static(nCells) = 1 where sgs_frc_static > 0, else 0
+  #
+  # Do not fall back to implicit ncremap SGS handling when this helper can be
+  # constructed, because the implicit path may reuse the time-dependent field.
+  if run_nco ncks -m "${tmp_f}" | grep -q "timeMonthly_avg_iceAreaCell"; then
+
+    # Construct spatial-only SGS fraction helper.
+    run_nco ncwa -O -a "${time_dim}" -y avg \
+      -v timeMonthly_avg_iceAreaCell \
+      "${tmp_f}" "${tmp_frc}"
+
+    run_nco ncrename -O \
+      -v timeMonthly_avg_iceAreaCell,sgs_frc_static \
+      "${tmp_frc}"
+
+    # Construct a spatial-only binary SGS mask from the static fraction.
+    # This avoids relying on timeMonthly_avg_icePresentIntMask, which may
+    # not be present in every split file.
+    run_nco ncap2 -O \
+      -s 'sgs_msk_static=(sgs_frc_static > 0.0)' \
+      "${tmp_frc}" "${tmp_msk}"
+
+    run_nco ncks -O -x -v sgs_frc_static "${tmp_msk}" "${tmp_msk}.only_msk"
+    mv "${tmp_msk}.only_msk" "${tmp_msk}"
+
+    # Append helper variables to the temporary file.
+    # This does not remove or overwrite the original time-dependent variables.
+    run_nco ncks -A "${tmp_frc}" "${tmp_f}"
+    run_nco ncks -A "${tmp_msk}" "${tmp_f}"
+
+    use_sgs_helpers="true"
+  else
+    echo "ERROR: timeMonthly_avg_iceAreaCell is missing in ${tmp_f}; cannot construct static SGS helpers for MPAS-Seaice."
+    cd {{ scriptDir }}
+    echo 'ERROR (3)' > {{ prefix }}.status
+    exit 3
+  fi
+
+  {%- endif %}
+
+  if [ "${use_sgs_helpers}" == "true" ]; then
+    run_nco ncremap \
+      -P {{ prc_typ }} \
+      --d2f \
+      --no_stagger \
+      -t 1 \
+      --nco_opt='--no_tmp_fl --hdr_pad=10000' \
+      --map={{ mapping_file }} \
+      --sgs_frc=sgs_frc_static \
+      --sgs_msk=sgs_msk_static \
+      --sgs_nrm=1.0 \
+      "${tmp_f}" \
+      "${out_f}"
+  else
+    run_nco ncremap \
+      -P {{ prc_typ }} \
+      --d2f \
+      --no_stagger \
+      -t 1 \
+      --nco_opt='--no_tmp_fl --hdr_pad=10000' \
+      --map={{ mapping_file }} \
+      "${tmp_f}" \
+      "${out_f}"
+  fi
+
+  rc=$?
+
+  # Remove temporary/helper variables from the final regridded output.
+  # Keep timeMonthly_avg_iceAreaCell only when it is the requested main variable.
+  if [ ${rc} == 0 ] && [ "{{ prc_typ }}" == "mpasseaice" ]; then
+    vars_to_remove="sgs_frc_static,sgs_msk_static"
+
+    if [ "${main_var}" != "timeMonthly_avg_iceAreaCell" ]; then
+      vars_to_remove="${vars_to_remove},timeMonthly_avg_iceAreaCell"
+    fi
+
+    # Remove helper variables only if at least one is present in the output.
+    remove_present="false"
+    for rm_var in $(echo "${vars_to_remove}" | tr ',' ' '); do
+      if run_nco ncks -m "${out_f}" | grep -qE "^[[:space:]]*[^:]+[[:space:]]+${rm_var}(\(|\[)"; then
+        remove_present="true"
+        break
+      fi
+    done
+
+    if [ "${remove_present}" == "true" ]; then
+      run_nco ncks -O -x -v "${vars_to_remove}" "${out_f}" "${out_f}.clean"
+      mv "${out_f}.clean" "${out_f}"
+      rc=$?
+    fi
+  fi
+
+  # Restore MPAS-native time metadata variables if needed.
+  # MPAS files often have a Time dimension and xtime_* variables, but no
+  # standard numeric coordinate variable named Time/time.
+  if [ ${rc} == 0 ]; then
+    for tvar in xtime_startMonthly xtime_endMonthly timeMonthly_avg_daysSinceStartOfSim; do
+      if run_nco ncks -m "${tmp_f}" | grep -q "${tvar}"; then
+        if ! run_nco ncks -m "${out_f}" | grep -q "${tvar}"; then
+          run_nco ncks -A -v "${tvar}" "${tmp_f}" "${out_f}"
+          rc=$?
+          if [ ${rc} != 0 ]; then
+            break
+          fi
+        fi
+      fi
+    done
+  fi
+
+  # Construct a CF-style numeric time coordinate if it is missing.
+  # Use MPAS days-since-start metadata:
+  #
+  #   timeMonthly_avg_daysSinceStartOfSim(Time)
+  #
+  # to create:
+  #
+  #   time(Time)
+  #     units    = "days since ${mpas_start_time}"
+  #     calendar = "${mpas_calendar}"
+  #
+  # This improves compatibility with downstream tools that expect a
+  # standard numeric time coordinate.
+  if [ ${rc} == 0 ]; then
+    if ! run_nco ncks -m "${out_f}" | grep -qE "^[[:space:]]*(float|double)[[:space:]]+time(\(|\[)"; then
+      if run_nco ncks -m "${tmp_f}" | grep -q "timeMonthly_avg_daysSinceStartOfSim"; then
+        tmp_time="tmp_time_${bname}"
+
+        run_nco ncks -O \
+          -v timeMonthly_avg_daysSinceStartOfSim \
+          "${tmp_f}" "${tmp_time}"
+
+        run_nco ncrename -O \
+          -v timeMonthly_avg_daysSinceStartOfSim,time \
+          "${tmp_time}"
+
+        run_nco ncatted -O \
+          -a units,time,o,c,"days since ${mpas_start_time}" \
+          -a calendar,time,o,c,"${mpas_calendar}" \
+          -a long_name,time,o,c,time \
+          -a standard_name,time,o,c,time \
+          "${tmp_time}"
+
+        run_nco ncks -A -v time "${tmp_time}" "${out_f}"
+        rc=$?
+
+        rm -f "${tmp_time}"
+      fi
+    fi
+  fi
+
+  # Add missing_value metadata only for the main floating-point data variable
+  # if it is missing. Avoid modifying coordinate or integer mask variables.
+  # Do not force-create _FillValue here, because some NetCDF workflows are
+  # sensitive to adding _FillValue after variable creation. Existing _FillValue
+  # attributes are preserved.
+  if [ ${rc} == 0 ]; then
+    if run_nco ncks -m "${out_f}" | grep -qE "^[[:space:]]*(float|double)[[:space:]]+${main_var}(\(|\[)"; then
+      if ! run_nco ncks -m "${out_f}" | grep -A8 -E "^[[:space:]]*(float|double)[[:space:]]+${main_var}(\(|\[)" | grep -q "missing_value"; then
+        run_nco ncatted -O \
+          -a missing_value,"${main_var}",o,f,1.0e36 \
+          "${out_f}"
+        rc=$?
+      fi
+    fi
+  fi
+
+  rm -f "${tmp_f}" "${tmp_frc}" "${tmp_msk}" "${tmp_msk}.only_msk" "${out_f}.clean"
+
+  if [ ${rc} != 0 ]; then
+    echo "ERROR: MPAS component regridding failed for ${bname}"
+    cd {{ scriptDir }}
+    echo 'ERROR (4)' > {{ prefix }}.status
+    exit 4
+  fi
+
+done
+
+{%- endif %}
 
 # Move output ts files to final destination
 {
@@ -120,8 +372,8 @@ fi
 }
 if [ $? != 0 ]; then
   cd {{ scriptDir }}
-  echo 'ERROR (3)' > {{ prefix }}.status
-  exit 3
+  echo 'ERROR (5)' > {{ prefix }}.status
+  exit 5
 fi
 
 # Delete temporary workdir


### PR DESCRIPTION
Add robust MPAS ocean/sea-ice time-series regridding

Split MPAS-Ocean and MPAS-Seaice time-series processing into native ncclimo generation followed by explicit ncremap regridding. This allows the workflow to restore MPAS-native time metadata, construct a CF-style numeric time coordinate from timeMonthly_avg_daysSinceStartOfSim, and preserve missing_value metadata after regridding.

For MPAS-Seaice, construct spatial-only SGS helper variables from timeMonthly_avg_iceAreaCell before regridding. This avoids failures when ncremap attempts to use the time-dependent timeMonthly_avg_iceAreaCell field directly as the SGS fraction. Temporary helper variables are removed from final output, and timeMonthly_avg_iceAreaCell is retained only when it is the requested output variable.

## Summary

Objectives:
- Add a separate MPAS-Ocean and MPAS-Seaice time-series regridding path using native ncclimo output followed by explicit ncremap regridding.
- Restore MPAS-native time metadata and construct a CF-style numeric time coordinate from timeMonthly_avg_daysSinceStartOfSim.
- Construct valid spatial-only SGS helper variables for MPAS-Seaice regridding to avoid using time-dependent timeMonthly_avg_iceAreaCell directly as the SGS fraction.
- Remove temporary helper variables from final regridded outputs while retaining timeMonthly_avg_iceAreaCell when it is the requested output variable.

Issue resolution:
- Closes #<ISSUE_NUMBER_HERE>

Select one: This pull request is...
- [x] a bug fix: increment the patch version
- [ ] a small improvement: increment the minor version
- [ ] a new feature: increment the minor version
- [ ] an incompatible (non-backwards compatible) API change: increment the major version

Please fill out either the "Small Change" or "Big Change" section (the latter includes the numbered subsections), and delete the other.

## Small Change

- [x] To merge, I will use "Squash and merge". That is, this change should be a single commit.
- [x] Logic: I have visually inspected the entire pull request myself.
- [ ] Pre-commit checks: All the pre-commits checks have passed.

## Big Change

- [ ] To merge, I will use "Create a merge commit". That is, this change is large enough to require multiple units of work (i.e., it should be multiple commits).

### 1. Does this do what we want it to do?

Required:
- [ ] Product Management: I have confirmed with the stakeholders that the objectives above are correct and complete.
- [ ] Testing: I have added or modified at least one "min-case" configuration file to test this change. Every objective above is represented in at least one cfg.
- [ ] Testing: I have considered likely and/or severe edge cases and have included them in testing.

If applicable:
- [ ] Testing: this pull request introduces an important feature or bug fix that we _must_ test often. I have updated the weekly-test configuration files, not just a "min-case" one.
- [ ] Testing: this pull request adds at least one new possible parameter to the cfg. I have tested using this parameter with and without any other parameter that may interact with it.

### 2. Are the implementation details accurate & efficient?

Required:
- [x] Logic: I have visually inspected the entire pull request myself.
- [x] Logic: I have left GitHub comments highlighting important pieces of code logic. I have had these code blocks reviewed by at least one other team member.

If applicable:
- [ ] Dependencies: This pull request introduces a new dependency. I have discussed this requirement with at least one other team member. The dependency is noted in `zppy/conda`, not just an `import` statement.

### 3. Is this well documented?

Required:
- [ ] Documentation: by looking at the docs, a new user could easily understand the functionality introduced by this pull request.

### 4. Is this code clean?

Required:
- [ ] Readability: The code is as simple as possible and well-commented, such that a new team member could understand what's happening.
- [ ] Pre-commit checks: All the pre-commits checks have passed.

If applicable:
- [x] Software architecture: I have discussed relevant trade-offs in design decisions with at least one other team member. It is unlikely that this pull request will increase tech debt.

### Configuration files used for test
```
# Directions to run:
# 1. Update <output>, <www>, <environment_commands_secondary> below.
# 2. Run with `zppy -c examples/post.v3.LR.amip.0101.cfg`.
# Direction to create stand-alone test data for zppy-interfaces:
# 3. Once the jobs finish, `cd <output>/post/scripts`.
# 4. Run `grep -n "Running a zi-pcmdi command" pcmdi_diags*.o*` to find the pcmdi_diags commands.
# 5. Then, you can run those lines stand-alone.
[default]
input = /pscratch/sd/z/zhan391/e3smv4_project/20260204.ne256.WCYCLXX1850.SOI
output = /pscratch/sd/z/zhan391/e3smv4_project/20260204.ne256.WCYCLXX1850.SOI
case = 20260204.ne256.WCYCLXX1850.SOI
www = /global/cfs/cdirs/e3sm/www/zhan391/eamxx-pcmdi

partition = "debug"
account = "e3sm"
#account = "priority"
campaign = "water_cycle"
debug = False
environment_commands = "source /global/common/software/e3sm/anaconda_envs/load_latest_e3sm_unified_pm-cpu.sh"

[ts]
active = True
walltime = "00:10:00"
years = "0001:0010:5"
ts_num_years=5


  [[ ocn_2d_monthly_180x360_aave ]]
  input_component = "mpaso"
  input_subdir = "archive/ocn/hist"
  input_files = "mpaso.hist.am.timeSeriesStatsMonthly"
  frequency = "monthly"
  mapping_file = /global/cfs/cdirs/e3sm/diagnostics/maps/map_RRSwISC6to18E3r5_to_cmip6_180x360_traave.20240327.nc
  vars="timeMonthly_avg_ssh,timeMonthly_avg_windStressZonal,timeMonthly_avg_windStressMeridional,timeMonthly_avg_surfaceBuoyancyForcing,timeMonthly_avg_oceanHeatContentSfcToBot,timeMonthly_avg_oceanHeatContentSfcTo700m,timeMonthly_avg_oceanHeatContent700mTo2000m,timeMonthly_avg_oceanHeatContent2000mToBot"
  extra_vars= "timeMonthly_avg_daysSinceStartOfSim,xtime_startMonthly,xtime_endMonthly"
  # MPAS calendar used to construct a CF-style numeric time coordinate
  mpas_calendar = "noleap"
  # MPAS simulation start time used as the reference time for time coordinate
  # This should match the MPAS/E3SM config_start_time 
  mpas_start_time = "0001-01-01 00:00:00"
  
  
  [[ ice_2d_monthly_180x360_aave ]]
  input_component = "mpassi"
  input_subdir = "archive/ice/hist"
  input_files = "mpassi.hist.am.timeSeriesStatsMonthly"
  frequency = "monthly"
  mapping_file = /global/cfs/cdirs/e3sm/diagnostics/maps/map_RRSwISC6to18E3r5_to_cmip6_180x360_traave.20240327.nc
  vars="timeMonthly_avg_icePresent,timeMonthly_avg_iceAreaCell,timeMonthly_avg_surfaceTemperatureCell,timeMonthly_avg_seaSurfaceTemperature,timeMonthly_avg_seaSurfaceSalinity,timeMonthly_avg_airTemperature,timeMonthly_avg_snowMelt,timeMonthly_avg_surfaceIceMelt,timeMonthly_avg_snowAlbedoCell" 
  extra_vars= "timeMonthly_avg_iceAreaCell,timeMonthly_avg_daysSinceStartOfSim,xtime_startMonthly,xtime_endMonthly"
  # MPAS calendar used to construct a CF-style numeric time coordinate
  mpas_calendar = "noleap"
  # MPAS simulation start time used as the reference time for time coordinate
  # This should match the MPAS/E3SM config_start_time 
  mpas_start_time = "0001-01-01 00:00:00"
  
```
  