### PR TITLE
Re-enable tc_analysis tests

### DIFF
--- a/tests/integration/template_weekly_bundles.cfg
+++ b/tests/integration/template_weekly_bundles.cfg
@@ -111,11 +111,10 @@ years = "1985:1989:2",
   [[ land_monthly ]]
   input_files = "elm.h0"
 
-# TODO: Add "tc_analysis" back in after empty dat is resolved.
-# [tc_analysis]
-# active = True
-# bundle = "bundle3" # Let bundle1 finish first because "e3sm_diags: atm_monthly_180x360_aave_mvm" requires "ts: atm_monthly_180x360_aave"
-# years = "1985:1989:2",
+[tc_analysis]
+active = #expand active_e3sm_diags#
+bundle = "bundle3" # Let bundle1 finish first because "e3sm_diags: atm_monthly_180x360_aave_mvm" requires "ts: atm_monthly_180x360_aave"
+years = "1985:1989:2",
 
 [e3sm_diags]
 active = #expand active_e3sm_diags#
@@ -144,8 +143,7 @@ years = "1985:1989:2",
   ref_years = "1985-1986",
   reference_data_path = "#expand user_output#zppy_weekly_bundles_output/#expand unique_id#/#expand case_name#/post/atm/180x360_aave/clim"
   run_type = "model_vs_model"
-  # TODO: Add "tc_analysis" back in after empty dat is resolved.
-  sets = "polar","enso_diags","streamflow",
+  sets = "polar","enso_diags","streamflow","tc_analysis",
   short_ref_name = "#expand case_name#"
   swap_test_ref = False
   tag = "model_vs_model"

--- a/tests/integration/template_weekly_comprehensive_v3.cfg
+++ b/tests/integration/template_weekly_comprehensive_v3.cfg
@@ -194,10 +194,10 @@ walltime = "00:30:00"
   input_files = "elm.h0"
   ts_subsection = "land_monthly"
 
-# TODO: Add "tc_analysis" back in after empty dat is resolved.
-# [tc_analysis]
-# active = True
-# walltime = "00:30:00"
+
+[tc_analysis]
+active = #expand active_e3sm_diags#
+walltime = "00:30:00"
 
 [e3sm_diags]
 active = #expand active_e3sm_diags#
@@ -220,9 +220,8 @@ ref_years = "1985-1986",
 # min_case_e3sm_diags_streamflow: "streamflow",
 # min_case_e3sm_diags_tc_analysis: "tc_analysis",
 # min_case_e3sm_diags_tropical_subseasonal: "tropical_subseasonal",
-# TODO: Add "tc_analysis" back in after empty dat is resolved.
 # TODO: Add "aerosol_budget" back in once that's working for v3.
-sets = "lat_lon","zonal_mean_xy","zonal_mean_2d","polar","cosp_histogram","meridional_mean_2d","annual_cycle_zonal_mean","zonal_mean_2d_stratosphere","enso_diags","qbo","diurnal_cycle","streamflow","tropical_subseasonal","aerosol_aeronet",
+sets = "lat_lon","zonal_mean_xy","zonal_mean_2d","polar","cosp_histogram","meridional_mean_2d","annual_cycle_zonal_mean","zonal_mean_2d_stratosphere","enso_diags","qbo","diurnal_cycle","streamflow","tc_analysis","tropical_subseasonal","aerosol_aeronet",
 short_name = "#expand case_name#"
 ts_daily_subsection = "atm_daily_180x360_aave"
 ts_num_years = 2

--- a/tests/integration/template_weekly_legacy_3.0.0_bundles.cfg
+++ b/tests/integration/template_weekly_legacy_3.0.0_bundles.cfg
@@ -113,11 +113,10 @@ years = "1985:1989:2",
   [[ land_monthly ]]
   input_files = "elm.h0"
 
-# TODO: Add "tc_analysis" back in after empty dat is resolved.
-# [tc_analysis]
-# active = True
-# bundle = "bundle3" # Let bundle1 finish first because "e3sm_diags: atm_monthly_180x360_aave_mvm" requires "ts: atm_monthly_180x360_aave"
-# years = "1985:1989:2",
+[tc_analysis]
+active = #expand active_e3sm_diags#
+bundle = "bundle3" # Let bundle1 finish first because "e3sm_diags: atm_monthly_180x360_aave_mvm" requires "ts: atm_monthly_180x360_aave"
+years = "1985:1989:2",
 
 [e3sm_diags]
 active = #expand active_e3sm_diags#
@@ -146,8 +145,7 @@ years = "1985:1989:2",
   ref_years = "1985-1986",
   reference_data_path = "#expand user_output#zppy_weekly_legacy_3.0.0_bundles_output/#expand unique_id#/#expand case_name#/post/atm/180x360_aave/clim"
   run_type = "model_vs_model"
-  # TODO: Add "tc_analysis" back in after empty dat is resolved.
-  sets = "polar","enso_diags","streamflow",
+  sets = "polar","enso_diags","streamflow","tc_analysis",
   short_ref_name = "#expand case_name#"
   swap_test_ref = False
   tag = "model_vs_model"

--- a/tests/integration/template_weekly_legacy_3.0.0_comprehensive_v3.cfg
+++ b/tests/integration/template_weekly_legacy_3.0.0_comprehensive_v3.cfg
@@ -114,10 +114,9 @@ walltime = "00:30:00"
   input_files = "elm.h0"
   ts_subsection = "land_monthly"
 
-# TODO: Add "tc_analysis" back in after empty dat is resolved.
-# [tc_analysis]
-# active = True
-# walltime = "00:30:00"
+[tc_analysis]
+active = #expand active_e3sm_diags#
+walltime = "00:30:00"
 
 [e3sm_diags]
 active = #expand active_e3sm_diags#
@@ -140,9 +139,8 @@ ref_years = "1985-1986",
 # min_case_e3sm_diags_streamflow: "streamflow",
 # min_case_e3sm_diags_tc_analysis: "tc_analysis",
 # min_case_e3sm_diags_tropical_subseasonal: "tropical_subseasonal",
-# TODO: Add "tc_analysis" back in after empty dat is resolved.
 # TODO: Add "aerosol_budget" back in once that's working for v3.
-sets = "lat_lon","zonal_mean_xy","zonal_mean_2d","polar","cosp_histogram","meridional_mean_2d","annual_cycle_zonal_mean","zonal_mean_2d_stratosphere","enso_diags","qbo","diurnal_cycle","streamflow","tropical_subseasonal","aerosol_aeronet",
+sets = "lat_lon","zonal_mean_xy","zonal_mean_2d","polar","cosp_histogram","meridional_mean_2d","annual_cycle_zonal_mean","zonal_mean_2d_stratosphere","enso_diags","qbo","diurnal_cycle","streamflow","tc_analysis","tropical_subseasonal","aerosol_aeronet",
 short_name = "#expand case_name#"
 ts_daily_subsection = "atm_daily_180x360_aave"
 ts_num_years = 2

--- a/tests/integration/template_weekly_legacy_3.1.0_bundles.cfg
+++ b/tests/integration/template_weekly_legacy_3.1.0_bundles.cfg
@@ -113,11 +113,10 @@ years = "1985:1989:2",
   [[ land_monthly ]]
   input_files = "elm.h0"
 
-# TODO: Add "tc_analysis" back in after empty dat is resolved.
-# [tc_analysis]
-# active = True
-# bundle = "bundle3" # Let bundle1 finish first because "e3sm_diags: atm_monthly_180x360_aave_mvm" requires "ts: atm_monthly_180x360_aave"
-# years = "1985:1989:2",
+[tc_analysis]
+active = #expand active_e3sm_diags#
+bundle = "bundle3" # Let bundle1 finish first because "e3sm_diags: atm_monthly_180x360_aave_mvm" requires "ts: atm_monthly_180x360_aave"
+years = "1985:1989:2",
 
 [e3sm_diags]
 active = #expand active_e3sm_diags#
@@ -146,8 +145,7 @@ years = "1985:1989:2",
   ref_years = "1985-1986",
   reference_data_path = "#expand user_output#zppy_weekly_legacy_3.1.0_bundles_output/#expand unique_id#/#expand case_name#/post/atm/180x360_aave/clim"
   run_type = "model_vs_model"
-  # TODO: Add "tc_analysis" back in after empty dat is resolved.
-  sets = "polar","enso_diags","streamflow",
+  sets = "polar","enso_diags","streamflow","tc_analysis",
   short_ref_name = "#expand case_name#"
   swap_test_ref = False
   tag = "model_vs_model"

--- a/tests/integration/template_weekly_legacy_3.1.0_comprehensive_v3.cfg
+++ b/tests/integration/template_weekly_legacy_3.1.0_comprehensive_v3.cfg
@@ -114,10 +114,9 @@ walltime = "00:30:00"
   input_files = "elm.h0"
   ts_subsection = "land_monthly"
 
-# TODO: Add "tc_analysis" back in after empty dat is resolved.
-# [tc_analysis]
-# active = True
-# walltime = "00:30:00"
+[tc_analysis]
+active = #expand active_e3sm_diags#
+walltime = "00:30:00"
 
 [e3sm_diags]
 active = #expand active_e3sm_diags#
@@ -140,9 +139,8 @@ ref_years = "1985-1986",
 # min_case_e3sm_diags_streamflow: "streamflow",
 # min_case_e3sm_diags_tc_analysis: "tc_analysis",
 # min_case_e3sm_diags_tropical_subseasonal: "tropical_subseasonal",
-# TODO: Add "tc_analysis" back in after empty dat is resolved.
 # TODO: Add "aerosol_budget" back in once that's working for v3.
-sets = "lat_lon","zonal_mean_xy","zonal_mean_2d","polar","cosp_histogram","meridional_mean_2d","annual_cycle_zonal_mean","zonal_mean_2d_stratosphere","enso_diags","qbo","diurnal_cycle","streamflow","tropical_subseasonal","aerosol_aeronet",
+sets = "lat_lon","zonal_mean_xy","zonal_mean_2d","polar","cosp_histogram","meridional_mean_2d","annual_cycle_zonal_mean","zonal_mean_2d_stratosphere","enso_diags","qbo","diurnal_cycle","streamflow","tc_analysis","tropical_subseasonal","aerosol_aeronet",
 short_name = "#expand case_name#"
 ts_daily_subsection = "atm_daily_180x360_aave"
 ts_num_years = 2


### PR DESCRIPTION
## Summary

Objectives:
- Re-enable `tc_analysis` sections in the `weekly` test templates.
- Re-enable `tc_analysis` sets for `e3sm_diags` in the the `weekly` test templates.

This will allow us to test #828 more thoroughly. After completing testing of that PR, we will determine whether to merge this PR or close it (and hopefully re-open/merge it in the future once `tc_analysis` is fully working again).

Select one: This pull request is...
- [ ] a bug fix: increment the patch version
- [x] a small improvement: increment the minor version
- [ ] a new feature: increment the minor version
- [ ] an incompatible (non-backwards compatible) API change: increment the major version

## Small Change

- [ ] To merge, I will use "Squash and merge". That is, this change should be a single commit.
- [ ] Logic: I have visually inspected the entire pull request myself.
- [ ] Pre-commit checks: All the pre-commits checks have passed.