### PR TITLE
Add tc_analysis to the EAMxx example (post.v3.eamxx.cfg)

### DIFF
--- a/examples/post.v3.eamxx.cfg
+++ b/examples/post.v3.eamxx.cfg
@@ -190,7 +190,7 @@ years = "1995:2004:10",
 # Chrysalis:
 #environment_commands = "source /home/ac.zhang40/y/etc/profile.d/conda.sh; conda activate e3sm_diags_eamxx_dev"
 # Perlmutter:
-environment_commands = "source /global/cfs/cdirs/e3sm/zhang40/miniconda3/etc/profile.d/conda.sh; conda activate e3sm_diags_eamxx_dev"
+environment_commands = "source /global/cfs/cdirs/e3sm/zhang40/miniconda3/etc/profile.d/conda.sh; conda activate e3sm_diags_main"
 
 # case inherits the top-level [default] case; climo output naming includes
 # the stream id automatically via fml_nm, so this subsection can consume

--- a/examples/post.v3.eamxx.cfg
+++ b/examples/post.v3.eamxx.cfg
@@ -123,7 +123,7 @@ ts_num_years=5
   [[ atm_monthly_glb ]]
   active = True
   # This subtask is a dependency for the global_time_series task.
-  input_component = "eam"
+  input_component = "eamxx"
   input_subdir = "run/"
   case = "1ma_ne30pg2"
   input_files = "AVERAGE.nmonths_x1"

--- a/examples/post.v3.eamxx.cfg
+++ b/examples/post.v3.eamxx.cfg
@@ -13,9 +13,9 @@
 # Run with: zppy -c examples/post.v3.eamxx.cfg
 [default]
 input = /pscratch/sd/z/zhan391/e3smv4_project/ne256pg2_ne256pg2.F20TR-SCREAMv1.July-1.spanc800.2xauto.acc150.n0032.test2.1
-output = /pscratch/sd/c/chengzhu/tests/ne256pg2_ne256pg2.F20TR-SCREAMv1.July-1.spanc800.2xauto.acc150.n0032.test2.1_05182026
+output = /pscratch/sd/c/chengzhu/tests/ne256pg2_ne256pg2.F20TR-SCREAMv1.July-1.spanc800.2xauto.acc150.n0032.test2.1_07062026
 case = ne256pg2_ne256pg2.F20TR-SCREAMv1.July-1.spanc800.2xauto.acc150.n0032.test2.1
-www = /global/cfs/cdirs/e3sm/www/chengzhu/tests/zppy_for_eamxx_05182026
+www = /global/cfs/cdirs/e3sm/www/chengzhu/tests/zppy_for_eamxx_07062026
 partition = "debug"
 account = "e3sm"
 campaign = "water_cycle"
@@ -187,7 +187,10 @@ ts_num_years = 5
 walltime = "2:00:00"
 years = "1995:2004:10",
 # Local e3sm_diags dev build (main branch, has EAMxx COSP support).
-environment_commands = "source /home/ac.zhang40/y/etc/profile.d/conda.sh; conda activate e3sm_diags_eamxx_dev"
+# Chrysalis:
+#environment_commands = "source /home/ac.zhang40/y/etc/profile.d/conda.sh; conda activate e3sm_diags_eamxx_dev"
+# Perlmutter:
+environment_commands = "source /global/cfs/cdirs/e3sm/zhang40/miniconda3/etc/profile.d/conda.sh; conda activate e3sm_diags_eamxx_dev"
 
 # case inherits the top-level [default] case; climo output naming includes
 # the stream id automatically via fml_nm, so this subsection can consume

--- a/examples/post.v3.eamxx.cfg
+++ b/examples/post.v3.eamxx.cfg
@@ -163,6 +163,20 @@ qos = "debug"
   input_files = "AVERAGE.nmonths_x1"
 
 
+[tc_analysis]
+# EAMxx TC tracking, dependency for the e3sm_diags "tc_analysis" set (zppy PR #828).
+active = True
+walltime = "02:00:00"
+years = "1995:2004:10",
+input_component = "eamxx"
+case = "6ha_ne30pg2"
+input_files = "AVERAGE.nhours_x6"
+input_subdir = "run/"
+# Required for EAMxx: --res and pg2 flag are derived from this.
+input_grid = "ne30pg2"
+# Ordered as SLP,T@200hPa,T@500hPa,U@bot,V@bot,U@850hPa,V@850hPa (EAM: PSL,T200,T500,UBOT,VBOT,U850,V850).
+tc_vars = "SeaLevelPressure,T_mid_at_200hPa,T_mid_at_500hPa,U_at_model_bot,V_at_model_bot,U_at_850hPa,V_at_850hPa"
+
 [e3sm_diags]
 active = True
 multiprocessing = True
@@ -172,6 +186,8 @@ ref_final_yr = 2004
 ts_num_years = 5
 walltime = "2:00:00"
 years = "1995:2004:10",
+# Local e3sm_diags dev build (main branch, has EAMxx COSP support).
+environment_commands = "source /home/ac.zhang40/y/etc/profile.d/conda.sh; conda activate e3sm_diags_eamxx_dev"
 
 # case inherits the top-level [default] case; climo output naming includes
 # the stream id automatically via fml_nm, so this subsection can consume
@@ -179,8 +195,7 @@ years = "1995:2004:10",
 
   [[ atm_monthly_180x360_aave ]]
   # `e3sm_diags` is largely driven by which e3sm_diags sets are requested:
-  sets="lat_lon","zonal_mean_xy","zonal_mean_2d","polar","cosp_histogram","meridional_mean_2d","annual_cycle_zonal_mean","enso_diags","qbo","zonal_mean_2d_stratosphere","aerosol_aeronet","mp_partition","tropical_subseasonal","precip_pdf","streamflow","diurnal_cycle",
-#  sets = #"tc_analysis," # not yet supported for eamxx!
+  sets="lat_lon","zonal_mean_xy","zonal_mean_2d","polar","cosp_histogram","meridional_mean_2d","annual_cycle_zonal_mean","enso_diags","qbo","zonal_mean_2d_stratosphere","aerosol_aeronet","mp_partition","tropical_subseasonal","precip_pdf","streamflow","diurnal_cycle","tc_analysis",
   climo_diurnal_frequency = "diurnal_8xdaily"
   climo_diurnal_subsection = "atm_monthly_diurnal_8xdaily_180x360_aave"
   ts_daily_subsection = "atm_daily_180x360_aave"


### PR DESCRIPTION
Extends the EAMxx example config to demonstrate TC tracking end-to-end.

## Changes to `examples/post.v3.eamxx.cfg`
- Add a `[tc_analysis]` section for EAMxx, using the `input_grid` + `tc_vars` parameters from #828 (`--res`/pg2 derived from `input_grid`; the seven tracking vars mapped from EAMxx names).
- Enable the `tc_analysis` set in `[e3sm_diags]` (previously commented out as "not yet supported for eamxx").
- Point `[e3sm_diags] environment_commands` at a local e3sm_diags build with EAMxx support (COSP + variable derivations), since that isn't in a released E3SM-Unified yet.

## Notes
- `input`, `output`, `www`, and `environment_commands` are machine/user-specific example paths (Perlmutter here) — change them for your setup before running.
- Validated with a `dry_run`: config validation passes and all tasks (climo, ts, e3sm_to_cmip, tc_analysis, e3sm_diags) generate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)