### PR TITLE
Enable global_time_series plots for EAMxx (post.v3.eamxx.cfg)

### DIFF
--- a/examples/post.v3.eamxx.cfg
+++ b/examples/post.v3.eamxx.cfg
@@ -129,7 +129,7 @@ ts_num_years=5
   input_files = "AVERAGE.nmonths_x1"
   frequency = "monthly"
   mapping_file = "glb"
-  vars="ps,surf_radiative_T,SeaLevelPressure,IceWaterPath,qv_2m,precip_liq_surf_mass_flux,precip_ice_surf_mass_flux"
+  vars="ps,surf_radiative_T,SeaLevelPressure,IceWaterPath,qv_2m,precip_liq_surf_mass_flux,precip_ice_surf_mass_flux,T_2m,surf_evap,surf_sens_flux,surface_upward_latent_heat_flux,SW_flux_dn_at_model_top,SW_flux_up_at_model_top,LW_flux_up_at_model_top,SW_flux_dn_at_model_bot,SW_flux_up_at_model_bot,LW_flux_up_at_model_bot,LW_flux_dn_at_model_bot"
 
 
   [[ rof_monthly ]]
@@ -206,3 +206,19 @@ environment_commands = "source /global/cfs/cdirs/e3sm/zhang40/miniconda3/etc/pro
   # [ts] subsection above, so no explicit override needed.
   grid = '180x360_aave'
   short_name = 'e3sm.amip.EAMXX.test2_1'
+
+[global_time_series]
+# Depends on the [ts] atm_monthly_glb subtask. EAMxx data is detected from the
+# glb variables (no config parameter); the classic plots are computed from the
+# EAMxx fields via zppy-interfaces' EAMxx variable mapping.
+active = True
+experiment_name = "EAMxx.test2_1"
+figstr = "EAMxx.test2_1"
+# The 3 ocean plots (change_ohc,max_moc,change_sea_level) are omitted: this
+# example has no mpas_analysis or ocean data.
+plots_original = "net_toa_flux_restom,global_surface_air_temperature,toa_radiation,net_atm_energy_imbalance,net_atm_water_imbalance"
+ts_num_years = 5
+years = "1995-2004",
+walltime = "00:30:00"
+# zppy-interfaces PR #53 (EAMxx support), installed into this env.
+environment_commands = "source /global/cfs/cdirs/e3sm/zhang40/miniconda3/etc/profile.d/conda.sh; conda activate zppy-interfaces-dev"


### PR DESCRIPTION
## Summary
Enables the classic `global_time_series` atmosphere plots for an EAMxx run, via `examples/post.v3.eamxx.cfg`. This is the zppy half of #846; the zppy-interfaces half is E3SM-Project/zppy-interfaces#53.

Two cfg-only changes (no zppy code change needed):

1. **`[ts] [[atm_monthly_glb]]` vars** — extended with the 11 EAMxx fields the classic atmosphere plots are computed from:
   `T_2m, surf_evap, surf_sens_flux, surface_upward_latent_heat_flux, SW_flux_dn/up_at_model_top, LW_flux_up_at_model_top, SW_flux_dn/up_at_model_bot, LW_flux_up/dn_at_model_bot`. Together with the `precip_liq/ice_surf_mass_flux` already present, these are exactly the EAMxx sources for `RESTOM`, `RESSURF`, `TREFHT`, TOA radiation (`FSNTOA`/`FLUT`), and `PRECT`, per PR #53's `eamxx_variables.py`.

2. **New `[global_time_series]` section** — produces the 5 atmosphere plots (`net_toa_flux_restom`, `global_surface_air_temperature`, `toa_radiation`, `net_atm_energy_imbalance`, `net_atm_water_imbalance`). The 3 ocean plots (`change_ohc`, `max_moc`, `change_sea_level`) are omitted since this example has no `mpas_analysis`/ocean data. `years`/`ts_num_years` kept consistent with `[ts]`.

EAMxx is detected from the glb variables present (no config parameter), so zppy needs no code change — only cfg work.

## Dependencies
- Requires E3SM-Project/zppy-interfaces#53 for the EAMxx variable mapping. The section's `environment_commands` currently points at a dev env with that branch installed; it can move to a released build once a new version of e3sm_unified with updated zppy-interfaces releases

## Testing
Ran `zppy -c examples/post.v3.eamxx.cfg` on Perlmutter; the `ts atm_monthly_glb` and `global_time_series` jobs were (re)submitted while all other tasks were skipped. Plot verification + RESTOM/temperature/TOA sanity checks passed.

Addresses #846.

🤖 Generated with [Claude Code](https://claude.com/claude-code)