### PR TITLE
Constrain sphinx <9.0.0 for sphinx-multiversion support

### DIFF
--- a/conda/dev.yml
+++ b/conda/dev.yml
@@ -26,7 +26,9 @@ dependencies:
   # Documentation
   # If versions are updated, also update in `.github/workflows/build_workflow.yml`
   # =================
-  - sphinx >=5.2.0
+  # Note: Sphinx 9.0.0 introduced a breaking change that prevents the `sphinx-multiversion` extension from working properly.
+  # Related: https://github.com/sphinx-contrib/multiversion/issues/201
+  - sphinx >=5.2.0,<9.0.0
   - sphinx-multiversion >=0.2.4
   - sphinx_rtd_theme >=1.0.0
   # Need to pin docutils because 0.17 has a bug with unordered lists


### PR DESCRIPTION
## Summary

Objectives:
- Constrain `sphinx` to resolve build issue.

Issue resolution:
- With https://github.com/E3SM-Project/zppy-interfaces/pull/55, closes https://github.com/E3SM-Project/zppy-interfaces/issues/54

Select one: This pull request is...
- [x] a bug fix: increment the patch version
- [ ] a small improvement: increment the minor version
- [ ] a new feature: increment the minor version
- [ ] an incompatible (non-backwards compatible) API change: increment the major version

## Small Change

- [ ] To merge, I will use "Squash and merge". That is, this change should be a single commit.
- [x] Logic: I have visually inspected the entire pull request myself.
- [x] Pre-commit checks: All the pre-commits checks have passed.